### PR TITLE
switched to find_package in CMakeLists.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: build
+      - name: build zenoh-c
+        shell: bash
+        run: |
+          git clone https://github.com/eclipse-zenoh/zenoh-c.git
+          cd zenoh-c
+          mkdir -p build && cd build 
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../../install
+          cmake --build . --target install
+
+      - name: build zenoh-cpp
         shell: bash
         run: |
           mkdir -p build && cd build 
-          cmake -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build .
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install
+          cmake --build . --target install
 
       - name: make examples
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if (NOT(zenohc_FOUND))
 	message(STATUS "zenohc build path: ${zenohc_build_path}")
 	message(STATUS "zenohc install path: ${zenohc_install_path}")
 	execute_process(COMMAND "cmake" ${zenohc_sources_path} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${zenohc_install_path} WORKING_DIRECTORY ${zenohc_build_path})
-	execute_process(COMMAND "cmake" --build . --target install WORKING_DIRECTORY ${zenohc_build_path})
+	execute_process(COMMAND "cmake" --build . --target install WORKING_DIRECTORY ${zenohc_build_path} TIMEOUT 1200)
 	find_package(zenohc ${CMAKE_PROJECT_VERSION} PATHS ${zenohc_install_path})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT CMAKE_BUILD_TYPE)
 
 	# Set the possible values of build type for cmake-gui
 	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-		"Debug" "Release" "MinSizeRel" "RelWithDebInfo" "Headers")
+		"Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -30,8 +30,6 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
 	set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/target/release")
 elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
 	set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/target/release")
-elseif(CMAKE_BUILD_TYPE STREQUAL "Headers")
-	set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/target/headers") # not used
 else()
 	message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 endif()
@@ -41,31 +39,7 @@ message(STATUS "build type: ${CMAKE_BUILD_TYPE}")
 # Configure targets depending on build type
 #
 
-if(NOT(CMAKE_BUILD_TYPE STREQUAL "Headers"))
-
-include(FetchContent)
-FetchContent_Declare(
-	zenohc_sources
-    # SOURCE_DIR "../../zenoh-c"
-    GIT_REPOSITORY https://github.com/eclipse-zenoh/zenoh-c
-)
-
 find_package(zenohc ${CMAKE_PROJECT_VERSION} QUIET)
-if (NOT(zenohc_FOUND))
-	FetchContent_Populate(zenohc_sources)
-	message(STATUS "Fetching zenohc")
-	FetchContent_GetProperties(zenohc_sources SOURCE_DIR zenohc_sources_path)
-	message(STATUS "Fetched zenohc into ${zenohc_sources_path}")
-	set(zenohc_build_path "${zenohc_sources_path}/build")
-	set(zenohc_install_path "${zenohc_sources_path}/install")
-	file(MAKE_DIRECTORY ${zenohc_build_path})
-	file(MAKE_DIRECTORY ${zenohc_install_path})
-	message(STATUS "zenohc build path: ${zenohc_build_path}")
-	message(STATUS "zenohc install path: ${zenohc_install_path}")
-	execute_process(COMMAND "cmake" ${zenohc_sources_path} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${zenohc_install_path} WORKING_DIRECTORY ${zenohc_build_path})
-	execute_process(COMMAND "cmake" --build . --target install WORKING_DIRECTORY ${zenohc_build_path} TIMEOUT 1200)
-	find_package(zenohc ${CMAKE_PROJECT_VERSION} PATHS ${zenohc_install_path})
-endif()
 
 add_library(zenohcpp INTERFACE)
 add_dependencies(zenohcpp zenohc::lib)
@@ -143,8 +117,6 @@ if(APPLE OR UNIX OR WIN32)
 	add_examples("${CMAKE_SOURCE_DIR}/examples/cpp/*.cpp" "cpp" TRUE)
 else()
 	message(WARNING "You platform doesn't seem to support building the examples or tests.")
-endif()
-
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 include(ExternalProject)
 project(
 	zenohcpp
@@ -37,63 +37,42 @@ else()
 endif()
 message(STATUS "build type: ${CMAKE_BUILD_TYPE}")
 
-set(zenohc_prefix "zenohc")
-set(zenohc_download_path "${CMAKE_CURRENT_BINARY_DIR}/${zenohc_prefix}/download")
-set(zenohc_install_path "${CMAKE_CURRENT_BINARY_DIR}/${zenohc_prefix}/install")
-
-message(STATUS "zenoh-c build-time download path: ${zenohc_download_path}")
-message(STATUS "zenoh-c build-time install path: ${zenohc_install_path}")
-
-set(libzenohc_include "${zenohc_install_path}/include/zenohc")
-file(MAKE_DIRECTORY ${libzenohc_include}) # INTERFACE_INCLUDE_DIRECTORIES requires that path should exist
-message(STATUS "zenoh-c headers: ${libzenohc_include}")
-
-if(APPLE)
-	set(libzenohc "${zenohc_install_path}/lib/libzenohc.dylib")
-	set(libzenohc_static "${zenohc_install_path}/lib/libzenohc.a")
-elseif(UNIX)
-	set(libzenohc "${zenohc_install_path}/lib/libzenohc.so")
-	set(libzenohc_static "${zenohc_install_path}/lib/libzenohc.a")
-elseif(WIN32)
-	set(libzenohc "${zenohc_install_path}/lib/zenohc.dll")
-	set(libzenohc_static "${zenohc_install_path}/lib/zenohc.lib")
-endif()
-message(STATUS "zenoh-c static library path : ${libzenohc_static}")
-message(STATUS "zenoh-c dynamic library path : ${libzenohc}")
-
 #
 # Configure targets depending on build type
 #
 
 if(NOT(CMAKE_BUILD_TYPE STREQUAL "Headers"))
 
-ExternalProject_add(
-    zenohc_project
-	CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${zenohc_install_path}
-	PREFIX ${zenohc_prefix}
+include(FetchContent)
+FetchContent_Declare(
+	zenohc_sources
     # SOURCE_DIR "../../zenoh-c"
-    SOURCE_DIR ${zenohc_download_path}
     GIT_REPOSITORY https://github.com/eclipse-zenoh/zenoh-c
 )
 
-add_library(zenohc SHARED IMPORTED)
-add_dependencies(zenohc zenohc_project)
-set_property(TARGET zenohc PROPERTY IMPORTED_NO_SONAME TRUE) # prevent linker from inserting into executable full path to the library
-set_property(TARGET zenohc PROPERTY IMPORTED_LOCATION "${libzenohc}")
-set_property(TARGET zenohc PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${libzenohc_include}")
-
-add_library(zenohc_static STATIC IMPORTED)
-add_dependencies(zenohc_static zenohc_project)
-set_property(TARGET zenohc_static PROPERTY IMPORTED_LOCATION "${libzenohc_static}")
-set_property(TARGET zenohc_static PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${libzenohc_include}")
+find_package(zenohc ${CMAKE_PROJECT_VERSION} QUIET)
+if (NOT(zenohc_FOUND))
+	FetchContent_Populate(zenohc_sources)
+	message(STATUS "Fetching zenohc")
+	FetchContent_GetProperties(zenohc_sources SOURCE_DIR zenohc_sources_path)
+	message(STATUS "Fetched zenohc into ${zenohc_sources_path}")
+	set(zenohc_build_path "${zenohc_sources_path}/build")
+	set(zenohc_install_path "${zenohc_sources_path}/install")
+	file(MAKE_DIRECTORY ${zenohc_build_path})
+	file(MAKE_DIRECTORY ${zenohc_install_path})
+	message(STATUS "zenohc build path: ${zenohc_build_path}")
+	message(STATUS "zenohc install path: ${zenohc_install_path}")
+	execute_process(COMMAND "cmake" ${zenohc_sources_path} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${zenohc_install_path} WORKING_DIRECTORY ${zenohc_build_path})
+	execute_process(COMMAND "cmake" --build . --target install WORKING_DIRECTORY ${zenohc_build_path})
+	find_package(zenohc ${CMAKE_PROJECT_VERSION} PATHS ${zenohc_install_path})
+endif()
 
 add_library(zenohcpp INTERFACE)
-add_dependencies(zenohcpp zenohc_project)
+add_dependencies(zenohcpp zenohc::lib)
 target_include_directories(zenohcpp INTERFACE "${CMAKE_SOURCE_DIR}/include")
 
 function(add_libraries target)
-	# target_link_libraries(${target} PUBLIC zenohc_static)
-	target_link_libraries(${target} PUBLIC zenohc)
+	target_link_libraries(${target} PUBLIC zenohc::lib)
 	if(APPLE)
 		find_library(FFoundation Foundation)
 		find_library(FSecurity Security)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ struct PutOptions : public Copyable<::z_put_options_t> {
 }
 ```
 
-These structures can be freely passed by value. They exacly matches corresponging [zenoh_c] structures (`z_put_options_t` in this case)
+These structures can be freely passed by value. They exacly matches corresponging [zenoh-c] structures (`z_put_options_t` in this case)
 and adds some necessary constructors and methods. For example `PutOptions` default constructor calls the zenoh function
 `z_put_options_default()`.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Check the website [zenoh.io](http://zenoh.io) and the [roadmap](https://github.c
 
 ## How to build and install it 
 
-The zenoh C++ API is just a set of C++ header wiles wrapping the [zenoh-c] (and [zenoh-pico] in nearest future) library. So to install and use the zenoh-cpp the
-[zenoh-c] should be installed also. Though this is not the case for running tests and examples in zenoh-cpp: the CMake build script downloads [zenoh-c] into build
-directory for these purposes.
+The zenoh C++ API is just a set of C++ header wiles wrapping the [zenoh-c] (and [zenoh-pico] in nearest future) library. 
+So to install and use the zenoh-cpp the [zenoh-c] should be installed also. 
 
 [zenoh-c]: https://github.com/eclipse-zenoh/zenoh-c
 [zenoh-cpp]: https://github.com/eclipse-zenoh/zenoh-cpp
@@ -41,31 +40,25 @@ The steps to install [zenoh-cpp]:
     brew install rust
     ```
 
-2. Clone the [zenoh-cpp] with `git`:
+2. Install [zenoh-c] library. If you don't want to use root privileges and install it into system `/usr/local` directory 
+add [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html) parameter to `cmake` arguments.
 
-    ```bash
-    git clone https://github.com/eclipse-zenoh/zenoh-cpp.git
-    cd zenoh-cpp
+    ```sh
+    git clone https://github.com/eclipse-zenoh/zenoh-c.git &&
+    cd zenoh-c && mkdir -p build && cd build &&
+    cmake .. -DCMAKE_INSTALL_PREFIX=../../local &&
+    cmake --build . --target install
     ```
 
-3. Install:
-
-* Install [zenoh-c] library as described in it's readme
-
-* Install [zenoh-cpp] headers:
-
-    ```bash
-    cd /path/to/zenoh-cpp
-    mkdir -p build && cd build 
-    cmake .. -DCMAKE_BUILD_TYPE=Headers # configure
-    cmake --build . --target install # install - run with `sudo` if necessary
+3. Install [zenoh-cpp]. Use the same `CMAKE_INSTALL_PREFIX` parameter as for [zenoh-c].  The key point is that this
+parameter is not only install destination path, but is also included into `CMAKE_SYSTEM_PREFIX_PATH`. So the CMAKE's 
+[find_package](https://cmake.org/cmake/help/latest/command/find_package.html) command is able to find [zenoh-c].
+    ```sh
+    git clone https://github.com/eclipse-zenoh/zenoh-cpp.git &&
+    cd zenoh-cpp && mkdir -p build && cd build &&
+    cmake .. -DCMAKE_INSTALL_PREFIX=../../local &&
+    cmake --build . --target install
     ```
-
-    Option `CMAKE_BUILD_TYPE=Headers` excludes slow step of downloading and building [zenoh-c] which is required for building 
-    tests and examples only and not needed to do install.
-
-    To install headers into path other than `/usr/local` add `-DCMAKE_INSTALL_PREFIX=/destination/path` option on cmake
-    onfigure step.
 
 ## Building and running tests
 


### PR DESCRIPTION
Removed zenoh-c download stage from zenoh-cpp building. Now zenoh-cpp build pocedure requires that zenoh-c is already installed and uses it as dependency. This made CMakeLists.txt much simpler and straightforward