### PR TITLE
covered keyexpr api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,18 @@ endif()
 message(STATUS "build type: ${CMAKE_BUILD_TYPE}")
 
 #
-# Configure targets depending on build type
+# Give priority to install directory when looking for zenoh-c
+# Useful for development when older zenohc version may be installed in system
 #
-
-find_package(zenohc ${CMAKE_PROJECT_VERSION} QUIET)
+# TODO: "if( NOT TARGET" below should be not necessary 
+# (see https://cmake.org/cmake/help/latest/command/find_package.html, search for "override the order")
+# but in fact cmake fails without it when zenohc is present both in CMAKE_INSTALL_PREFIX and in /usr/local.
+# Consider is it still necessary after next bumping up cmake version
+#
+find_package(zenohc ${CMAKE_PROJECT_VERSION} PATHS ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH QUIET)
+if(NOT TARGET zenohc::lib)
+	find_package(zenohc ${CMAKE_PROJECT_VERSION} QUIET)
+endif()
 
 add_library(zenohcpp INTERFACE)
 add_dependencies(zenohcpp zenohc::lib)

--- a/include/zenohcpp_objects.h
+++ b/include/zenohcpp_objects.h
@@ -25,6 +25,7 @@ namespace zenoh {
 class KeyExpr : public Owned<::z_owned_keyexpr_t> {
    public:
     using Owned::Owned;
+    explicit KeyExpr(nullptr_t) : Owned(nullptr) {}
     explicit KeyExpr(const char* name) : Owned(::z_keyexpr_new(name)) {}
     KeyExprView as_keyexpr_view() const { return KeyExprView(::z_keyexpr_loan(&_0)); }
     operator KeyExprView() const { return as_keyexpr_view(); }

--- a/include/zenohcpp_objects.h
+++ b/include/zenohcpp_objects.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <variant>
 
 #include "zenoh.h"
@@ -21,13 +22,48 @@
 
 namespace zenoh {
 
-class KeyExpr : Owned<::z_owned_keyexpr_t> {
+class KeyExpr : public Owned<::z_owned_keyexpr_t> {
    public:
     using Owned::Owned;
     explicit KeyExpr(const char* name) : Owned(::z_keyexpr_new(name)) {}
-    operator KeyExprView() const { return KeyExprView(::z_keyexpr_loan(&_0)); }
-    // TODO: add keyexpr operations: equals, includes, intersects, canonize, etc...
+    KeyExprView as_keyexpr_view() const { return KeyExprView(::z_keyexpr_loan(&_0)); }
+    operator KeyExprView() const { return as_keyexpr_view(); }
+    BytesView as_bytes() const { return as_keyexpr_view().as_bytes(); }
+    std::string_view as_string_view() const { return as_keyexpr_view().as_string_view(); }
+    bool operator==(const std::string_view& v) { return as_string_view() == v; }
+    KeyExpr concat(const std::string_view& s) const { return as_keyexpr_view().concat(s); }
+    KeyExpr join(const KeyExprView& v) const { return as_keyexpr_view().join(v); }
+    bool equals(const KeyExprView& v) const { return as_keyexpr_view().equals(v); }
+    bool includes(const KeyExprView& v, ErrNo& error) const { return as_keyexpr_view().includes(v, error); }
+    bool includes(const KeyExprView& v) const { return as_keyexpr_view().includes(v); }
+    bool intersects(const KeyExprView& v, ErrNo& error) const { return as_keyexpr_view().intersects(v, error); }
+    bool intersects(const KeyExprView& v) const { return as_keyexpr_view().intersects(v); }
 };
+
+KeyExpr KeyExprView::concat(const std::string_view& s) const { return ::z_keyexpr_concat(*this, s.data(), s.length()); }
+KeyExpr KeyExprView::join(const KeyExprView& v) const { return ::z_keyexpr_join(*this, v); }
+
+bool keyexpr_canonize(std::string& s, ErrNo& error) {
+    uintptr_t len = s.length();
+    error = ::z_keyexpr_canonize(&s[0], &len);
+    s.resize(len);
+    return error == 0;
+}
+
+bool keyexpr_canonize(std::string& s) {
+    ErrNo error;
+    return keyexpr_canonize(s, error);
+}
+
+bool keyexpr_is_canon(const std::string_view& s, ErrNo& error) {
+    error = ::z_keyexpr_is_canon(s.begin(), s.length());
+    return error == 0;
+}
+
+bool keyexpr_is_canon(const std::string_view& s) {
+    ErrNo error;
+    return keyexpr_is_canon(s, error);
+}
 
 class ScoutingConfig;
 

--- a/include/zenohcpp_structs.h
+++ b/include/zenohcpp_structs.h
@@ -102,6 +102,7 @@ inline bool _split_ret_to_bool_and_err(int8_t ret, ErrNo& error) {
 
 struct KeyExprView : public Copyable<::z_keyexpr_t> {
     using Copyable::Copyable;
+    KeyExprView(nullptr_t) : Copyable(::z_keyexpr(nullptr)) {}  // allow to create uninitialized KeyExprView
     KeyExprView(const char* name) : Copyable(::z_keyexpr(name)) {}
     bool check() const { return ::z_keyexpr_is_initialized(this); }
     BytesView as_bytes() const { return BytesView{::z_keyexpr_as_bytes(*this)}; }

--- a/include/zenohcpp_structs.h
+++ b/include/zenohcpp_structs.h
@@ -60,6 +60,7 @@ struct BytesView : public Copyable<::z_bytes_t> {
     BytesView(const std::string& s)
         : Copyable({.start = reinterpret_cast<const uint8_t*>(s.data()), .len = s.length()}) {}
     std::string_view as_string_view() const { return std::string_view(reinterpret_cast<const char*>(start), len); }
+    bool operator==(const BytesView& v) const { return as_string_view() == v.as_string_view(); }
 };
 
 struct Id : public Copyable<::z_id_t> {
@@ -99,6 +100,11 @@ struct Encoding : public Copyable<::z_encoding_t> {
     Encoding() : Copyable(::z_encoding_default()) {}
     Encoding(EncodingPrefix _prefix) : Copyable(::z_encoding(_prefix, nullptr)) {}
     Encoding(EncodingPrefix _prefix, const char* _suffix) : Copyable(::z_encoding(_prefix, _suffix)) {}
+    EncodingPrefix get_prefix() const { return prefix; }
+    const BytesView& get_suffix() const { return static_cast<const BytesView&>(suffix); }
+    bool operator==(const Encoding& v) const {
+        return get_prefix() == v.get_prefix() && get_suffix() == v.get_suffix();
+    }
 };
 
 struct Timestamp : Copyable<::z_timestamp_t> {
@@ -122,9 +128,24 @@ struct Value : public Copyable<::z_value_t> {
     const BytesView& get_payload() const { return static_cast<const BytesView&>(payload); }
     const Encoding& get_encoding() const { return static_cast<const Encoding&>(encoding); }
     std::string_view as_string_view() const { return get_payload().as_string_view(); }
+    bool operator==(const Value& v) const {
+        return get_payload() == v.get_payload() && get_encoding() == v.get_encoding();
+    }
 };
 
 typedef Value ErrorMessage;
+
+struct QueryConsolidation : Copyable<::z_query_consolidation_t> {
+    using Copyable::Copyable;
+    QueryConsolidation() : Copyable(::z_query_consolidation_default()) {}
+    QueryConsolidation(ConsolidationMode v) : Copyable({v}) {}
+    QueryConsolidation& set_mode(ConsolidationMode v) {
+        mode = v;
+        return *this;
+    }
+    ConsolidationMode get_mode() const { return mode; }
+    bool operator==(const QueryConsolidation& v) const { return get_mode() == v.get_mode(); }
+};
 
 struct GetOptions : public Copyable<::z_get_options_t> {
     using Copyable::Copyable;
@@ -133,9 +154,22 @@ struct GetOptions : public Copyable<::z_get_options_t> {
         target = v;
         return *this;
     }
-    GetOptions& set_consolidation(ConsolidationMode v) {
-        consolidation.mode = v;
+    GetOptions& set_consolidation(QueryConsolidation v) {
+        consolidation = v;
         return *this;
+    }
+    GetOptions& set_with_value(Value v) {
+        with_value = v;
+        return *this;
+    }
+    QueryTarget get_target() const { return target; }
+    const QueryConsolidation& get_consolidation() const {
+        return static_cast<const QueryConsolidation&>(consolidation);
+    }
+    const Value& get_with_value() const { return static_cast<const Value&>(with_value); }
+    bool operator==(const GetOptions& v) const {
+        return get_target() == v.get_target() && get_consolidation() == v.get_consolidation() &&
+               get_with_value() == v.get_with_value();
     }
 };
 

--- a/tests/closures_func.cpp
+++ b/tests/closures_func.cpp
@@ -17,6 +17,9 @@
 
 using namespace zenoh;
 
+#undef NDEBUG
+#include <assert.h>
+
 int gcnt = 0;
 
 void on_reply_lv(Reply) { gcnt++; };

--- a/tests/closures_obj_ptr_param.cpp
+++ b/tests/closures_obj_ptr_param.cpp
@@ -17,6 +17,9 @@
 
 using namespace zenoh;
 
+#undef NDEBUG
+#include <assert.h>
+
 int gcnt = 0;
 
 struct OnQuery {

--- a/tests/closures_obj_ref_param.cpp
+++ b/tests/closures_obj_ref_param.cpp
@@ -17,6 +17,9 @@
 
 using namespace zenoh;
 
+#undef NDEBUG
+#include <assert.h>
+
 int gcnt = 0;
 
 struct OnReply {

--- a/tests/keyexpr.cpp
+++ b/tests/keyexpr.cpp
@@ -22,6 +22,9 @@ using namespace zenoh;
 void key_expr_view() {
     KeyExprView nul(nullptr);
     assert(!nul.check());
+    KeyExprView nulstr((const char*)nullptr);
+    assert(!nulstr.check());
+
     KeyExprView foo("FOO");
     assert(foo.check());
     assert(foo == "FOO");
@@ -32,6 +35,9 @@ void key_expr_view() {
 void key_expr() {
     KeyExpr nul(nullptr);
     assert(!nul.check());
+    KeyExpr nulstr((const char*)nullptr);
+    assert(!nulstr.check());
+
     KeyExpr foo("FOO");
     assert(foo.check());
     assert(foo == "FOO");

--- a/tests/keyexpr.cpp
+++ b/tests/keyexpr.cpp
@@ -1,0 +1,168 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#include "zenohcpp.h"
+
+using namespace zenoh;
+
+#undef NDEBUG
+#include <assert.h>
+
+void key_expr_view() {
+    KeyExprView nul(nullptr);
+    assert(!nul.check());
+    KeyExprView foo("FOO");
+    assert(foo.check());
+    assert(foo == "FOO");
+    assert(foo.as_bytes() == "FOO");
+    assert(foo.as_string_view() == "FOO");
+}
+
+void key_expr() {
+    KeyExpr nul(nullptr);
+    assert(!nul.check());
+    KeyExpr foo("FOO");
+    assert(foo.check());
+    assert(foo == "FOO");
+    assert(foo.as_bytes() == "FOO");
+    assert(foo.as_string_view() == "FOO");
+    assert(foo.as_keyexpr_view() == "FOO");
+}
+
+void canonize() {
+    ErrNo err;
+    bool res;
+    auto non_canon = "a/**/**/c";
+    auto canon = "a/**/c";
+
+    assert(keyexpr_is_canon(canon));
+    assert(!keyexpr_is_canon(non_canon));
+    assert(keyexpr_is_canon(canon, err));
+    assert(err == 0);
+    assert(!keyexpr_is_canon(non_canon, err));
+    assert(err != 0);
+
+    std::string foo(non_canon);
+    res = keyexpr_canonize(foo, err);
+    assert(foo == canon);
+    assert(err == 0);
+    assert(res);
+}
+
+void concat() {
+    KeyExprView foov("FOO");
+    auto foobar = foov.concat("BAR");
+    assert(foobar == "FOOBAR");
+
+    KeyExpr foo("FOO");
+    auto foobar1 = foo.concat("BAR");
+    assert(foobar1 == "FOOBAR");
+}
+
+void join() {
+    KeyExprView foov("FOO");
+    auto foobar = foov.concat("BAR");
+    assert(foobar == "FOO/BAR");
+
+    KeyExpr foo("FOO");
+    auto foobar1 = foo.concat("BAR");
+    assert(foobar1 == "FOO/BAR");
+}
+
+void equals() {
+    KeyExpr foo("FOO");
+    KeyExprView foov("FOO");
+    KeyExpr bar("BAR");
+    KeyExprView barv("BAR");
+
+    assert(foo.equals(foo));
+    assert(foo.equals(foov));
+    assert(foov.equals(foo));
+    assert(foov.equals(foov));
+
+    assert(!foo.equals(bar));
+    assert(!foo.equals(barv));
+    assert(!foov.equals(bar));
+    assert(!foov.equals(barv));
+}
+
+void includes() {
+    KeyExprView nul(nullptr);
+    ErrNo err;
+
+    KeyExprView foostarv("FOO/*");
+    KeyExprView foobarv("FOO/BAR");
+    assert(foostarv.includes(foobarv));
+    assert(foostarv.includes(foobarv, err));
+    assert(err == 0);
+    assert(!foobarv.includes(foostarv));
+    assert(!foobarv.includes(foostarv, err));
+    assert(err == 0);
+    assert(!foostarv.includes(nul));
+    assert(!foostarv.includes(nul, err));
+    assert(err != 0);
+
+    KeyExpr foostar("FOO/*");
+    KeyExpr foobar("FOO/BAR");
+    assert(foostar.includes(foobar));
+    assert(foostar.includes(foobar, err));
+    assert(err == 0);
+    assert(!foobar.includes(foostar));
+    assert(!foobar.includes(foostar, err));
+    assert(err == 0);
+    assert(!foostar.includes(nul));
+    assert(!foostar.includes(nul, err));
+    assert(err != 0);
+}
+
+void intersects() {
+    KeyExprView nul(nullptr);
+    ErrNo err;
+
+    KeyExprView foostarv("FOO/*");
+    KeyExprView foobarv("FOO/BAR");
+    KeyExprView starbuzv("*/BUZ");
+    assert(foostarv.intersects(foobarv));
+    assert(!starbuzv.intersects(foobarv));
+    assert(!foostarv.intersects(nul));
+    assert(foostarv.intersects(foobarv, err));
+    assert(err == 0);
+    assert(!starbuzv.intersects(foobarv, err));
+    assert(err == 0);
+    assert(!foostarv.intersects(nul, err));
+    assert(err != 0);
+
+    KeyExpr foostar("FOO/*");
+    KeyExpr foobar("FOO/BAR");
+    KeyExpr starbuz("*/BUZ");
+    assert(foostar.intersects(foobar));
+    assert(!starbuz.intersects(foobar));
+    assert(!foostar.intersects(nul));
+    assert(foostar.intersects(foobar, err));
+    assert(err == 0);
+    assert(!starbuz.intersects(foobar, err));
+    assert(err == 0);
+    assert(!foostar.intersects(nul, err));
+    assert(err != 0);
+}
+
+int main(int argc, char** argv) {
+    key_expr_view();
+    key_expr();
+    canonize();
+    concat();
+    equals();
+    includes();
+    intersects();
+};

--- a/tests/options.cpp
+++ b/tests/options.cpp
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#include "zenohcpp.h"
+
+using namespace zenoh;
+
+#undef NDEBUG
+#include <assert.h>
+
+void get_options() {
+    GetOptions opts;
+    opts.set_consolidation(QueryConsolidation())
+        .set_consolidation(Z_CONSOLIDATION_MODE_AUTO)
+        .set_target(Z_QUERY_TARGET_ALL)
+        .set_with_value("TEST");
+
+    GetOptions opts2 = opts;
+    assert(opts2 == opts);
+    assert(opts.get_consolidation() == QueryConsolidation(Z_CONSOLIDATION_MODE_AUTO));
+    assert(opts.get_target() == Z_QUERY_TARGET_ALL);
+    assert(opts.get_with_value() == Value("TEST"));
+}
+
+int main(int argc, char** argv) { get_options(); };


### PR DESCRIPTION
- function for keyexpr (join, includes, canonize, etc.) added
- GetOptions covered
- tests added

Related to issues:
https://github.com/eclipse-zenoh/zenoh-cpp/issues/12
https://github.com/eclipse-zenoh/zenoh-cpp/issues/6