### PR TITLE
made different string and keyexpr for zenoh-c and zenoh-pico examples

### DIFF
--- a/examples/universal/z_delete.cxx
+++ b/examples/universal/z_delete.cxx
@@ -13,12 +13,20 @@
 //
 #include <iostream>
 
+#ifdef ZENOHCXX_ZENOHC
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-c-put";
+#elif ZENOHCXX_ZENOHPICO
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-pico-put";
+#else
+#error "Unknown zenoh backend"
+#endif
+
 #include "stdio.h"
 #include "zenoh.hxx"
 using namespace zenoh;
 
 int _main(int argc, char **argv) {
-    const char *keyexpr = "demo/example/zenoh-cpp-put";
+    const char *keyexpr = default_keyexpr;
     const char *locator = nullptr;
 
     if (argc > 1) keyexpr = argv[1];

--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -28,9 +28,19 @@
 #include "zenoh.hxx"
 using namespace zenoh;
 
+#ifdef ZENOHCXX_ZENOHC
+const char *default_value = "Pub from C++ zenoh-c!";
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-c-pub";
+#elif ZENOHCXX_ZENOHPICO
+const char *default_value = "Pub from C++ zenoh-pico!";
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-pico-pub";
+#else
+#error "Unknown zenoh backend"
+#endif
+
 int _main(int argc, char **argv) {
-    const char *keyexpr = "demo/example/zenoh-cpp-pub";
-    const char *value = "Pub from CPP!";
+    const char *keyexpr = default_keyexpr;
+    const char *value = default_value;
     const char *locator = nullptr;
 
     if (argc > 1) keyexpr = argv[1];

--- a/examples/universal/z_pub_delete.cxx
+++ b/examples/universal/z_pub_delete.cxx
@@ -17,8 +17,16 @@
 #include "zenoh.hxx"
 using namespace zenoh;
 
+#ifdef ZENOHCXX_ZENOHC
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-c-pub";
+#elif ZENOHCXX_ZENOHPICO
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-pico-pub";
+#else
+#error "Unknown zenoh backend"
+#endif
+
 int _main(int argc, char **argv) {
-    const char *keyexpr = "demo/example/zenoh-cpp-pub";
+    const char *keyexpr = default_keyexpr;
     const char *locator = nullptr;
 
     if (argc > 1) keyexpr = argv[1];

--- a/examples/universal/z_put.cxx
+++ b/examples/universal/z_put.cxx
@@ -17,9 +17,17 @@
 #include "zenoh.hxx"
 using namespace zenoh;
 
+#ifdef ZENOHCXX_ZENOHC
+const char *default_value = "Put from C++ zenoh-c!";
+#elif ZENOHCXX_ZENOHPICO
+const char *default_value = "Put from C++ zenoh-pico!";
+#else
+#error "Unknown zenoh backend"
+#endif
+
 int _main(int argc, char **argv) {
     const char *keyexpr = "demo/example/zenoh-cpp-put";
-    const char *value = "Put from CPP!";
+    const char *value = default_value;
     const char *locator = nullptr;
 
     if (argc > 1) keyexpr = argv[1];

--- a/examples/universal/z_put.cxx
+++ b/examples/universal/z_put.cxx
@@ -19,14 +19,16 @@ using namespace zenoh;
 
 #ifdef ZENOHCXX_ZENOHC
 const char *default_value = "Put from C++ zenoh-c!";
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-c-put";
 #elif ZENOHCXX_ZENOHPICO
 const char *default_value = "Put from C++ zenoh-pico!";
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-pico-put";
 #else
 #error "Unknown zenoh backend"
 #endif
 
 int _main(int argc, char **argv) {
-    const char *keyexpr = "demo/example/zenoh-cpp-put";
+    const char *keyexpr = default_keyexpr;
     const char *value = default_value;
     const char *locator = nullptr;
 

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -25,10 +25,11 @@
 #include "zenoh.hxx"
 using namespace zenoh;
 
-const char *expr = "demo/example/zenoh-cpp-queryable";
 #ifdef ZENOHCXX_ZENOHC
+const char *expr = "demo/example/zenoh-cpp-zenoh-c-queryable";
 const char *value = "Queryable from C++ zenoh-c!";
 #elif ZENOHCXX_ZENOHPICO
+const char *expr = "demo/example/zenoh-cpp-zenoh-pico-queryable";
 const char *value = "Queryable from C++ zenoh-pico!";
 #else
 #error "Unknown zenoh backend"

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -26,7 +26,13 @@
 using namespace zenoh;
 
 const char *expr = "demo/example/zenoh-cpp-queryable";
-const char *value = "Queryable from CPP!";
+#ifdef ZENOHCXX_ZENOHC
+const char *value = "Queryable from C++ zenoh-c!";
+#elif ZENOHCXX_ZENOHPICO
+const char *value = "Queryable from C++ zenoh-pico!";
+#else
+#error "Unknown zenoh backend"
+#endif
 const char *locator = nullptr;
 
 int _main(int argc, char **argv) {


### PR DESCRIPTION
The different values and keyexprs are necessary to diffentiate zenoh-c and zenoh-pico examples in https://github.com/ZettaScaleLabs/zenoh-tests