### PR TITLE
Fix missing inline

### DIFF
--- a/include/zenohcxx/impl.hxx
+++ b/include/zenohcxx/impl.hxx
@@ -180,7 +180,7 @@ inline std::variant<z::ShmManager, z::ErrorMessage> shm_manager_new(const z::Ses
     return std::move(shm_manager);
 }
 
-std::variant<z::Shmbuf, z::ErrorMessage> z::ShmManager::alloc(uintptr_t capacity) const {
+inline std::variant<z::Shmbuf, z::ErrorMessage> z::ShmManager::alloc(uintptr_t capacity) const {
     auto shmbuf = z::Shmbuf(std::move(::zc_shm_alloc(&_0, capacity)));
     if (!shmbuf.check()) return "Failed to allocate shared memor buffer";
     return std::move(shmbuf);


### PR DESCRIPTION
This missing inline was breaking compilation when `zenoh` is included from multiple `.c`, causing the symbol to be defined multiple times, breaking linkage.