### PR TITLE
loan method added to Owned base class

### DIFF
--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -1321,13 +1321,13 @@ class Str : public Owned<::z_owned_str_t> {
 
     /// @brief Get the string value
     /// @return ``const char*`` null-terminated string pointer
-    const char* c_str() const { return ::z_loan(_0); }
+    const char* c_str() const { return loan(); }
 
     /// @name Operators
 
     /// @brief Get the string value
     /// @return ``const char*`` null-terminated string pointer
-    operator const char*() const { return ::z_loan(_0); }
+    operator const char*() const { return loan(); }
 
     /// @brief Equality operator
     /// @param s the ``std::string_view`` to compare with
@@ -1357,7 +1357,7 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
 
     /// @brief Get the key expression value
     /// @return ``KeyExprView`` referencing the key expression value in the object
-    z::KeyExprView as_keyexpr_view() const { return z::KeyExprView(::z_keyexpr_loan(&_0)); }
+    z::KeyExprView as_keyexpr_view() const { return z::KeyExprView(loan()); }
 
     /// @brief Get the key expression value
     /// @return ``BytesView`` referencing the key expression value in the object
@@ -1444,28 +1444,26 @@ class Config : public Owned<::z_owned_config_t> {
     /// @param key the key
     /// @return the ``Str`` value of the config parameter
     /// @note zenoh-c only
-    z::Str get(const char* key) const { return z::Str(::zc_config_get(::z_config_loan(&_0), key)); }
+    z::Str get(const char* key) const { return z::Str(::zc_config_get(loan(), key)); }
 
     /// @brief Get the whole config as a JSON string
     /// @return the JSON string in ``Str``
     /// @note zenoh-c only
-    z::Str to_string() const { return z::Str(::zc_config_to_string(::z_config_loan(&_0))); }
+    z::Str to_string() const { return z::Str(::zc_config_to_string(loan())); }
 
     /// @brief Insert a config parameter by the string key
     /// @param key the key
     /// @param value the JSON string value
     /// @return true if the parameter was inserted
     /// @note zenoh-c only
-    bool insert_json(const char* key, const char* value) {
-        return ::zc_config_insert_json(::z_config_loan(&_0), key, value) == 0;
-    }
+    bool insert_json(const char* key, const char* value) { return ::zc_config_insert_json(loan(), key, value) == 0; }
 #endif
 #ifdef __ZENOHCXX_ZENOHPICO
     /// @brief Get config parameter by it's numeric ID
     /// @param key the key
     /// @return pointer to the null-terminated string value of the config parameter
     /// @note zenoh-pico only
-    const char* get(uint8_t key) const { return ::zp_config_get(::z_config_loan(&_0), key); }
+    const char* get(uint8_t key) const { return ::zp_config_get(loan(), key); }
 
     /// @brief Insert a config parameter by it's numeric ID
     /// @param key the key
@@ -1558,13 +1556,13 @@ class PullSubscriber : public Owned<::z_owned_pull_subscriber_t> {
 
     /// @brief Pull the next sample
     /// @return true if the sample was pulled, false otherwise
-    bool pull() { return ::z_subscriber_pull(::z_loan(_0)) == 0; }
+    bool pull() { return ::z_subscriber_pull(loan()) == 0; }
 
     /// @brief Pull the next sample
     /// @param error the error code
     /// @return true if the sample was pulled, false otherwise
     bool pull(ErrNo& error) {
-        error = ::z_subscriber_pull(::z_loan(_0));
+        error = ::z_subscriber_pull(loan());
         return error == 0;
     }
 };
@@ -1673,7 +1671,7 @@ class Hello : public Owned<::z_owned_hello_t> {
 
     /// @brief Get the content of the hello message
     /// @return the content of the hello message as ``HelloView``
-    operator z::HelloView() const { return z::HelloView(::z_hello_loan(&_0)); }
+    operator z::HelloView() const { return z::HelloView(loan()); }
 };
 
 /// @brief Callback type passed to ``Session::get``to process ``Reply``s from ``Queryable``s
@@ -1756,12 +1754,12 @@ class Session : public Owned<::z_owned_session_t> {
     /// This is possible in zenoh-c only where ``Session`` is a reference counted object.
     /// @return a new ``Session`` instance
     /// @note zenoh-c only
-    Session rcinc() { return Session(::zc_session_rcinc(::z_session_loan(&_0))); }
+    Session rcinc() { return Session(::zc_session_rcinc(loan())); }
 #endif
 
     /// @brief Get the unique identifier of the zenoh node associated to this ``Session``
     /// @return the unique identifier ``Id``
-    z::Id info_zid() const { return ::z_info_zid(::z_session_loan(&_0)); }
+    z::Id info_zid() const { return ::z_info_zid(loan()); }
 
     /// @brief Create ``KeyExpr`` instance with numeric id registered in ``Session`` routing tables
     /// @param keyexpr ``KeyExprView`` representing string key expression

--- a/include/zenohcxx/base.hxx
+++ b/include/zenohcxx/base.hxx
@@ -105,6 +105,14 @@ class Owned {
     /// Check object validity uzing zenoh API
     bool check() const { return ::z_check(_0); }
 
+    /// @brief Get zenoh-c loan structure ``z_XXX_t`` associated with owned object ``z_owned_XXX_t``
+    /// if the corresponding zenoh-c function ``z_loan`` is defined/
+    /// @return zenoh-c loan structure ``z_XXX_t``
+    template <typename ZC_LOAN_TYPE = decltype(::z_loan(*static_cast<const ZC_OWNED_TYPE*>(nullptr)))>
+    ZC_LOAN_TYPE loan() const {
+        return ::z_loan(_0);
+    }
+
     /// @name Operators
 
     /// Get read/write direct access to wrapped zenoh structure

--- a/include/zenohcxx/impl.hxx
+++ b/include/zenohcxx/impl.hxx
@@ -30,7 +30,8 @@ inline void init_logger() { ::zc_init_logger(); }
 inline ::z_bytes_t z::BytesView::init(const uint8_t* start, size_t len) {
     ::z_bytes_t ret = {len, start
 #ifdef __ZENOHCXX_ZENOHPICO
-                       ,false
+                       ,
+                       false
 #endif
     };
     return ret;
@@ -104,7 +105,7 @@ inline bool keyexpr_canonize(std::string& s) {
 }
 
 inline bool keyexpr_is_canon(const std::string_view& s, ErrNo& error) {
-    error = ::z_keyexpr_is_canon(s.data() , s.length());
+    error = ::z_keyexpr_is_canon(s.data(), s.length());
     return error == 0;
 }
 
@@ -169,7 +170,7 @@ inline std::variant<z::Config, ErrorMessage> config_client(const std::initialize
 }
 
 inline z::ShmManager::ShmManager(const z::Session& session, const char* id, uintptr_t size)
-    : Owned(std::move(::zc_shm_manager_new(::z_loan(static_cast<const ::z_owned_session_t&>(session)), id, size))) {}
+    : Owned(std::move(::zc_shm_manager_new(session.loan(), id, size))) {}
 
 inline std::variant<z::ShmManager, z::ErrorMessage> shm_manager_new(const z::Session& session, const char* id,
                                                                     uintptr_t size) {
@@ -187,7 +188,7 @@ inline std::variant<z::Shmbuf, z::ErrorMessage> z::ShmManager::alloc(uintptr_t c
 #endif
 
 inline z::ScoutingConfig z::Config::create_scouting_config() {
-    return z::ScoutingConfig(::z_scouting_config_from(::z_loan(_0)));
+    return z::ScoutingConfig(::z_scouting_config_from(loan()));
 }
 
 inline bool z::Publisher::put(const z::BytesView& payload, const PublisherPutOptions& options, ErrNo& error) {
@@ -239,19 +240,19 @@ inline bool z::Publisher::put_owned(z::Payload&& payload) {
 #endif
 
 inline bool z::Publisher::put_impl(const z::BytesView& payload, const PublisherPutOptions* options, ErrNo& error) {
-    error = ::z_publisher_put(::z_loan(_0), payload.start, payload.len, options);
+    error = ::z_publisher_put(loan(), payload.start, payload.len, options);
     return error == 0;
 }
 
 inline bool z::Publisher::delete_impl(const PublisherDeleteOptions* options, ErrNo& error) {
-    error = ::z_publisher_delete(::z_loan(_0), options);
+    error = ::z_publisher_delete(loan(), options);
     return error == 0;
 }
 
 #ifdef __ZENOHCXX_ZENOHC
 
 inline bool z::Publisher::put_owned_impl(z::Payload&& payload, const z::PublisherPutOptions* options, ErrNo& error) {
-    error = ::zc_publisher_put_owned(::z_loan(_0), &static_cast<::zc_owned_payload_t&>(payload), options);
+    error = ::zc_publisher_put_owned(loan(), &static_cast<::zc_owned_payload_t&>(payload), options);
     return error == 0;
 }
 
@@ -270,7 +271,7 @@ inline bool scout(z::ScoutingConfig&& config, ClosureHello&& callback) {
 }
 
 inline z::KeyExpr z::Session::declare_keyexpr(const z::KeyExprView& keyexpr) {
-    return z::KeyExpr(::z_declare_keyexpr(::z_session_loan(&_0), keyexpr));
+    return z::KeyExpr(::z_declare_keyexpr(loan(), keyexpr));
 }
 
 inline bool z::Session::undeclare_keyexpr(z::KeyExpr&& keyexpr, ErrNo& error) {
@@ -389,51 +390,51 @@ inline std::variant<z::Publisher, ErrorMessage> z::Session::declare_publisher(z:
 
 inline bool z::Session::info_routers_zid(ClosureZid&& callback, ErrNo& error) {
     auto c = callback.take();
-    error = ::z_info_routers_zid(::z_session_loan(&_0), &c);
+    error = ::z_info_routers_zid(loan(), &c);
     return error == 0;
 }
 inline bool z::Session::info_routers_zid(ClosureZid&& callback) {
     auto c = callback.take();
-    return ::z_info_routers_zid(::z_session_loan(&_0), &c) == 0;
+    return ::z_info_routers_zid(loan(), &c) == 0;
 }
 
 inline bool z::Session::info_peers_zid(ClosureZid&& callback, ErrNo& error) {
     auto c = callback.take();
-    error = ::z_info_peers_zid(::z_session_loan(&_0), &c);
+    error = ::z_info_peers_zid(loan(), &c);
     return error == 0;
 }
 inline bool z::Session::info_peers_zid(ClosureZid&& callback) {
     auto c = callback.take();
-    return ::z_info_peers_zid(::z_session_loan(&_0), &c) == 0;
+    return ::z_info_peers_zid(loan(), &c) == 0;
 }
 
 inline bool z::Session::undeclare_keyexpr_impl(KeyExpr&& keyexpr, ErrNo& error) {
-    error = ::z_undeclare_keyexpr(::z_session_loan(&_0), &(static_cast<::z_owned_keyexpr_t&>(keyexpr)));
+    error = ::z_undeclare_keyexpr(loan(), &(static_cast<::z_owned_keyexpr_t&>(keyexpr)));
     return error == 0;
 }
 
 inline bool z::Session::get_impl(z::KeyExprView keyexpr, const char* parameters, ClosureReply&& callback,
                                  const GetOptions* options, ErrNo& error) {
     auto c = callback.take();
-    error = ::z_get(::z_session_loan(&_0), keyexpr, parameters, &c, options);
+    error = ::z_get(loan(), keyexpr, parameters, &c, options);
     return error == 0;
 }
 
 inline bool z::Session::put_impl(z::KeyExprView keyexpr, const z::BytesView& payload, const PutOptions* options,
                                  ErrNo& error) {
-    error = ::z_put(::z_session_loan(&_0), keyexpr, payload.start, payload.len, options);
+    error = ::z_put(loan(), keyexpr, payload.start, payload.len, options);
     return error == 0;
 }
 
 inline bool z::Session::delete_impl(z::KeyExprView keyexpr, const DeleteOptions* options, ErrNo& error) {
-    error = ::z_delete(::z_session_loan(&_0), keyexpr, options);
+    error = ::z_delete(loan(), keyexpr, options);
     return error == 0;
 }
 
 #ifdef __ZENOHCXX_ZENOHC
 inline bool z::Session::put_owned_impl(z::KeyExprView keyexpr, z::Payload&& payload, const PutOptions* options,
                                        ErrNo& error) {
-    error = ::zc_put_owned(::z_session_loan(&_0), keyexpr, &(static_cast<::zc_owned_payload_t&>(payload)), options);
+    error = ::zc_put_owned(loan(), keyexpr, &(static_cast<::zc_owned_payload_t&>(payload)), options);
     return error == 0;
 }
 #endif
@@ -442,7 +443,7 @@ inline std::variant<z::Queryable, ErrorMessage> z::Session::declare_queryable_im
                                                                                    ClosureQuery&& callback,
                                                                                    const QueryableOptions* options) {
     auto c = callback.take();
-    z::Queryable queryable(::z_declare_queryable(::z_session_loan(&_0), keyexpr, &c, options));
+    z::Queryable queryable(::z_declare_queryable(loan(), keyexpr, &c, options));
     if (queryable.check()) {
         return std::move(queryable);
     } else {
@@ -454,7 +455,7 @@ inline std::variant<z::Subscriber, ErrorMessage> z::Session::declare_subscriber_
                                                                                      ClosureSample&& callback,
                                                                                      const SubscriberOptions* options) {
     auto c = callback.take();
-    z::Subscriber subscriber(::z_declare_subscriber(::z_session_loan(&_0), keyexpr, &c, options));
+    z::Subscriber subscriber(::z_declare_subscriber(loan(), keyexpr, &c, options));
     if (subscriber.check()) {
         return std::move(subscriber);
     } else {
@@ -465,7 +466,7 @@ inline std::variant<z::Subscriber, ErrorMessage> z::Session::declare_subscriber_
 inline std::variant<z::PullSubscriber, ErrorMessage> z::Session::declare_pull_subscriber_impl(
     z::KeyExprView keyexpr, ClosureSample&& callback, const PullSubscriberOptions* options) {
     auto c = callback.take();
-    z::PullSubscriber pull_subscriber(::z_declare_pull_subscriber(::z_session_loan(&_0), keyexpr, &c, options));
+    z::PullSubscriber pull_subscriber(::z_declare_pull_subscriber(loan(), keyexpr, &c, options));
     if (pull_subscriber.check()) {
         return std::move(pull_subscriber);
     } else {
@@ -475,7 +476,7 @@ inline std::variant<z::PullSubscriber, ErrorMessage> z::Session::declare_pull_su
 
 inline std::variant<z::Publisher, ErrorMessage> z::Session::declare_publisher_impl(z::KeyExprView keyexpr,
                                                                                    const PublisherOptions* options) {
-    z::Publisher publisher(::z_declare_publisher(::z_session_loan(&_0), keyexpr, options));
+    z::Publisher publisher(::z_declare_publisher(loan(), keyexpr, options));
     if (publisher.check()) {
         return std::move(publisher);
     } else {
@@ -533,7 +534,7 @@ inline bool z::Config::insert(uint8_t key, const char* value) {
 }
 
 inline bool z::Config::insert(uint8_t key, const char* value, ErrNo& error) {
-    error = ::zp_config_insert(::z_config_loan(&_0), key, ::z_string_make(value));
+    error = ::zp_config_insert(loan(), key, ::z_string_make(value));
     return error == 0;
 }
 
@@ -545,7 +546,7 @@ inline bool Session::start_read_task() {
     return start_read_task(error);
 }
 inline bool Session::start_read_task(ErrNo& error) {
-    error = ::zp_start_read_task(::z_session_loan(&_0), nullptr);
+    error = ::zp_start_read_task(loan(), nullptr);
     return error == 0;
 }
 inline bool Session::stop_read_task() {
@@ -553,7 +554,7 @@ inline bool Session::stop_read_task() {
     return stop_read_task(error);
 }
 inline bool Session::stop_read_task(ErrNo& error) {
-    error = ::zp_stop_read_task(::z_session_loan(&_0));
+    error = ::zp_stop_read_task(loan());
     return error == 0;
 }
 inline bool Session::start_lease_task() {
@@ -561,7 +562,7 @@ inline bool Session::start_lease_task() {
     return start_lease_task(error);
 }
 inline bool Session::start_lease_task(ErrNo& error) {
-    error = ::zp_start_lease_task(::z_session_loan(&_0), nullptr);
+    error = ::zp_start_lease_task(loan(), nullptr);
     return error == 0;
 }
 inline bool Session::stop_lease_task() {
@@ -569,7 +570,7 @@ inline bool Session::stop_lease_task() {
     return stop_lease_task(error);
 }
 inline bool Session::stop_lease_task(ErrNo& error) {
-    error = ::zp_stop_lease_task(::z_session_loan(&_0));
+    error = ::zp_stop_lease_task(loan());
     return error == 0;
 }
 inline bool Session::read() {
@@ -577,7 +578,7 @@ inline bool Session::read() {
     return read(error);
 }
 inline bool Session::read(ErrNo& error) {
-    error = ::zp_read(::z_session_loan(&_0), nullptr);
+    error = ::zp_read(loan(), nullptr);
     return error == 0;
 }
 inline bool Session::send_keep_alive() {
@@ -585,7 +586,7 @@ inline bool Session::send_keep_alive() {
     return send_keep_alive(error);
 }
 inline bool Session::send_keep_alive(ErrNo& error) {
-    error = ::zp_send_keep_alive(::z_session_loan(&_0), nullptr);
+    error = ::zp_send_keep_alive(loan(), nullptr);
     return error == 0;
 }
 inline bool Session::send_join() {
@@ -593,7 +594,7 @@ inline bool Session::send_join() {
     return send_join(error);
 }
 inline bool Session::send_join(ErrNo& error) {
-    error = ::zp_send_join(::z_session_loan(&_0), nullptr);
+    error = ::zp_send_join(loan(), nullptr);
     return error == 0;
 }
 #endif


### PR DESCRIPTION
the  `loan` method is avaliable only if `z_loan` funcion is defined.
This helped to shorten code and remove some casts