### PR TITLE
make keyexpr functions standalone

### DIFF
--- a/docs/keyexpr.rst
+++ b/docs/keyexpr.rst
@@ -15,9 +15,10 @@
 Key Expressions
 ===============
 
-Classes implementing key expressions. See `zenoh abstractions`_ for details.
+Classes implementing key expressions. See `zenoh abstractions`_ and `Key Expression RFC`_ for details.
 
 .. _`zenoh abstractions`: https://zenoh.io/docs/manual/abstractions/
+.. _`Key Expression RFC`: https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Key%20Expressions.md
 
 .. doxygenfunction:: keyexpr_canonize(std::string& s, ErrNo& error)
 

--- a/docs/keyexpr.rst
+++ b/docs/keyexpr.rst
@@ -27,6 +27,22 @@ Classes implementing key expressions. See `zenoh abstractions`_ for details.
 
 .. doxygenfunction:: keyexpr_is_canon(const std::string_view& s)
 
+.. doxygenfunction:: keyexpr_concat(const zenoh::KeyExprView& k, const std::string_view& s)
+
+.. doxygenfunction:: keyexpr_join(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
+
+.. doxygenfunction:: keyexpr_equals(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
+
+.. doxygenfunction:: keyexpr_equals(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
+
+.. doxygenfunction:: keyexpr_includes(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
+
+.. doxygenfunction:: keyexpr_includes(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
+
+.. doxygenfunction:: keyexpr_intersects(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
+
+.. doxygenfunction:: keyexpr_intersects(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
+
 .. doxygenstruct:: zenoh::KeyExprUnchecked
    :members:
    :membergroups: Constructors Operators Methods

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -385,7 +385,7 @@ inline z::KeyExpr keyexpr_concat(const z::KeyExprView& k, const std::string_view
 /// @param v the key expression to join with
 /// @return Newly allocated key expression ``zenoh::KeyExpr``
 /// @note zenoh-c only
-inline z::KeyExpr keyexpr_join(const z::KeyExprView& a, const KeyExprView& b);
+inline z::KeyExpr keyexpr_join(const z::KeyExprView& a, const z::KeyExprView& b);
 #endif
 
 /// @brief Checks if the key expression is equal to another key expression
@@ -393,12 +393,12 @@ inline z::KeyExpr keyexpr_join(const z::KeyExprView& a, const KeyExprView& b);
 /// @param error Error code returned by ``::z_keyexpr_equals`` (value < -1 if any of the key expressions is not
 /// valid)
 /// @return true the key expression is equal to the other key expression
-inline bool keyexr_equals(const KeyExprView& a, const KeyExprView& b, ErrNo& error);
+inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
 
 /// @brief Checks if the key expression is equal to another key expression
 /// @param v Another key expression
 /// @return true the key expression is equal to the other key expression
-inline bool keyexr_equals(const KeyExprView& a, const KeyExprView& b);
+inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b);
 
 /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
 /// expression contains the set defined by the other key expression
@@ -406,13 +406,13 @@ inline bool keyexr_equals(const KeyExprView& a, const KeyExprView& b);
 /// @param error Error code returned by ``::z_keyexpr_includes`` (value < -1 if any of the key expressions is not
 /// valid)
 /// @return true the key expression includes the other key expression
-inline bool keyexr_includes(const KeyExprView& a, const KeyExprView& b, ErrNo& error);
+inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
 
 /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
 /// expression contains the set defined by the other key expression
 /// @param v Another key expression
 /// @return true the key expression includes the other key expression
-inline bool keyexr_includes(const KeyExprView& a, const KeyExprView& b);
+inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b);
 
 /// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
 /// which is contained in both of the sets defined by the key expressions
@@ -420,13 +420,13 @@ inline bool keyexr_includes(const KeyExprView& a, const KeyExprView& b);
 /// @param error Error code returned by ``::z_keyexpr_intersects`` (value < -1 if any of the key expressions is not
 /// valid)
 /// @return true the key expression intersects with the other key expression
-inline bool keyexr_intersects(const KeyExprView& a, const KeyExprView& b, ErrNo& error);
+inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
 
 /// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
 /// which is contained in both of the sets defined by the key expressions
 /// @param v Another key expression
 /// @return true the key expression intersects with the other key expression
-inline bool keyexr_intersects(const KeyExprView& a, const KeyExprView& b);
+inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b);
 
 /// The non-owning read-only view to a key expression in Zenoh.
 struct KeyExprView : public Copyable<::z_keyexpr_t> {
@@ -488,6 +488,37 @@ struct KeyExprView : public Copyable<::z_keyexpr_t> {
     /// @brief Return the key expression as a ``std::string_view``
     /// @return ``std::string_view`` representing the key expression
     std::string_view as_string_view() const { return as_bytes().as_string_view(); }
+
+#ifdef __ZENOHCXX_ZENOHC
+    // operator += purposedly not defined to not provoke ambiguity between concat (which
+    // mechanically connects strings) and join (which works with path elements)
+
+    /// @brief see ``zenoh::keyexpr_concat``
+    /// @note zenoh-c only
+    z::KeyExpr concat(const std::string_view& s) const;
+
+    /// @brief see ``zenoh::keyexpr_join``
+    /// @note zenoh-c only
+    z::KeyExpr join(const z::KeyExprView& v) const;
+#endif
+
+    /// @brief see ``zenoh::keyexpr_equals``
+    bool equals(const z::KeyExprView& v, ErrNo& error) const;
+
+    /// @brief see ``zenoh::keyexpr_equals``
+    bool equals(const z::KeyExprView& v) const;
+
+    /// @brief see ``zenoh::keyexpr_includes``
+    bool includes(const z::KeyExprView& v, ErrNo& error) const;
+
+    /// @brief see ``zenoh::keyexpr_includes``
+    bool includes(const z::KeyExprView& v) const;
+
+    /// @brief see ``zenoh::keyexpr_intersects``
+    bool intersects(const z::KeyExprView& v, ErrNo& error) const;
+
+    /// @brief see ``zenoh::keyexpr_intersects``
+    bool intersects(const z::KeyExprView& v) const;
 };
 
 /// The encoding of a payload, in a MIME-like format.
@@ -1376,6 +1407,34 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     /// @param v the ``std::string_view`` to compare with
     /// @return true if the key expression is equal to the string
     bool operator==(const std::string_view& v) { return as_string_view() == v; }
+
+#ifdef __ZENOHCXX_ZENOHC
+    /// @brief see ``zenoh::keyexpr_concat``
+    /// @note zenoh-c only
+    z::KeyExpr concat(const std::string_view& s) const;
+
+    /// @brief see ``zenoh::keyexpr_join``
+    /// @note zenoh-c only
+    z::KeyExpr join(const z::KeyExprView& v) const;
+#endif
+
+    /// @brief see ``zenoh::keyexpr_equals``
+    bool equals(const z::KeyExprView& v, ErrNo& error) const;
+
+    /// @brief see ``zenoh::keyexpr_equals``
+    bool equals(const z::KeyExprView& v) const;
+
+    /// @brief see ``zenoh::keyexpr_includes``
+    bool includes(const z::KeyExprView& v, ErrNo& error) const;
+
+    /// @brief see ``zenoh::keyexpr_includes``
+    bool includes(const z::KeyExprView& v) const;
+
+    /// @brief see ``zenoh::keyexpr_intersects``
+    bool intersects(const z::KeyExprView& v, ErrNo& error) const;
+
+    /// @brief see ``zenoh::keyexpr_intersects``
+    bool intersects(const z::KeyExprView& v) const;
 };
 
 class ScoutingConfig;

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -344,6 +344,7 @@ struct HelloView : public Copyable<::z_hello_t> {
 };
 
 class KeyExpr;
+class KeyExprView;
 
 /// Empty type used to distinguish checked and unchecked constructing of KeyExprView
 struct KeyExprUnchecked {
@@ -372,6 +373,60 @@ inline bool keyexpr_is_canon(const std::string_view& s, ErrNo& error);
 /// @param s ``std::string_view`` with key expression
 /// @return true if the key expression is canonical, false otherwise
 inline bool keyexpr_is_canon(const std::string_view& s);
+
+#ifdef __ZENOHCXX_ZENOHC
+/// @brief Concatenate the key expression and a string
+/// @param s ``std::string_view`` representing a key expression
+/// @return Newly allocated key expression ``zenoh::KeyExpr``
+/// @note zenoh-c only
+inline z::KeyExpr keyexpr_concat(const z::KeyExprView& k, const std::string_view& s);
+
+/// @brief Join key expression with another key expression, inserting a separator between them
+/// @param v the key expression to join with
+/// @return Newly allocated key expression ``zenoh::KeyExpr``
+/// @note zenoh-c only
+inline z::KeyExpr keyexpr_join(const z::KeyExprView& a, const KeyExprView& b);
+#endif
+
+/// @brief Checks if the key expression is equal to another key expression
+/// @param v Another key expression
+/// @param error Error code returned by ``::z_keyexpr_equals`` (value < -1 if any of the key expressions is not
+/// valid)
+/// @return true the key expression is equal to the other key expression
+inline bool keyexr_equals(const KeyExprView& a, const KeyExprView& b, ErrNo& error);
+
+/// @brief Checks if the key expression is equal to another key expression
+/// @param v Another key expression
+/// @return true the key expression is equal to the other key expression
+inline bool keyexr_equals(const KeyExprView& a, const KeyExprView& b);
+
+/// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
+/// expression contains the set defined by the other key expression
+/// @param v Another key expression
+/// @param error Error code returned by ``::z_keyexpr_includes`` (value < -1 if any of the key expressions is not
+/// valid)
+/// @return true the key expression includes the other key expression
+inline bool keyexr_includes(const KeyExprView& a, const KeyExprView& b, ErrNo& error);
+
+/// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
+/// expression contains the set defined by the other key expression
+/// @param v Another key expression
+/// @return true the key expression includes the other key expression
+inline bool keyexr_includes(const KeyExprView& a, const KeyExprView& b);
+
+/// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
+/// which is contained in both of the sets defined by the key expressions
+/// @param v Another key expression
+/// @param error Error code returned by ``::z_keyexpr_intersects`` (value < -1 if any of the key expressions is not
+/// valid)
+/// @return true the key expression intersects with the other key expression
+inline bool keyexr_intersects(const KeyExprView& a, const KeyExprView& b, ErrNo& error);
+
+/// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
+/// which is contained in both of the sets defined by the key expressions
+/// @param v Another key expression
+/// @return true the key expression intersects with the other key expression
+inline bool keyexr_intersects(const KeyExprView& a, const KeyExprView& b);
 
 /// The non-owning read-only view to a key expression in Zenoh.
 struct KeyExprView : public Copyable<::z_keyexpr_t> {
@@ -433,62 +488,6 @@ struct KeyExprView : public Copyable<::z_keyexpr_t> {
     /// @brief Return the key expression as a ``std::string_view``
     /// @return ``std::string_view`` representing the key expression
     std::string_view as_string_view() const { return as_bytes().as_string_view(); }
-#ifdef __ZENOHCXX_ZENOHC
-    // operator += purposedly not defined to not provoke ambiguity between concat (which
-    // mechanically connects strings) and join (which works with path elements)
-
-    /// @brief Concatenate the key expression and a string
-    /// @param s ``std::string_view`` representing a key expression
-    /// @return Newly allocated key expression ``zenoh::KeyExpr``
-    /// @note zenoh-c only
-    z::KeyExpr concat(const std::string_view& s) const;
-
-    /// @brief Join key expression with another key expression, inserting a separator between them
-    /// @param v the key expression to join with
-    /// @return Newly allocated key expression ``zenoh::KeyExpr``
-    /// @note zenoh-c only
-    z::KeyExpr join(const KeyExprView& v) const;
-#endif
-
-    /// @brief Checks if the key expression is equal to another key expression
-    /// @param v Another key expression
-    /// @param error Error code returned by ``::z_keyexpr_equals`` (value < -1 if any of the key expressions is not
-    /// valid)
-    /// @return true the key expression is equal to the other key expression
-    bool equals(const KeyExprView& v, ErrNo& error) const;
-
-    /// @brief Checks if the key expression is equal to another key expression
-    /// @param v Another key expression
-    /// @return true the key expression is equal to the other key expression
-    bool equals(const KeyExprView& v) const;
-
-    /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
-    /// expression contains the set defined by the other key expression
-    /// @param v Another key expression
-    /// @param error Error code returned by ``::z_keyexpr_includes`` (value < -1 if any of the key expressions is not
-    /// valid)
-    /// @return true the key expression includes the other key expression
-    bool includes(const KeyExprView& v, ErrNo& error) const;
-
-    /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
-    /// expression contains the set defined by the other key expression
-    /// @param v Another key expression
-    /// @return true the key expression includes the other key expression
-    bool includes(const KeyExprView& v) const;
-
-    /// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
-    /// which is contained in both of the sets defined by the key expressions
-    /// @param v Another key expression
-    /// @param error Error code returned by ``::z_keyexpr_intersects`` (value < -1 if any of the key expressions is not
-    /// valid)
-    /// @return true the key expression intersects with the other key expression
-    bool intersects(const KeyExprView& v, ErrNo& error) const;
-
-    /// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
-    /// which is contained in both of the sets defined by the key expressions
-    /// @param v Another key expression
-    /// @return true the key expression intersects with the other key expression
-    bool intersects(const KeyExprView& v) const;
 };
 
 /// The encoding of a payload, in a MIME-like format.
@@ -1366,55 +1365,6 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     /// @brief Get the key expression value
     /// @return ``std::string_view`` referencing the key expression value in the object
     std::string_view as_string_view() const { return as_keyexpr_view().as_string_view(); }
-#ifdef __ZENOHCXX_ZENOHC
-    /// @brief Concatenate the key expression and a string
-    /// @param s ``std::string_view`` representing a key expression
-    /// @return Newly allocated key expression ``zenoh::KeyExpr``
-    /// @note zenoh-c only
-    z::KeyExpr concat(const std::string_view& s) const { return as_keyexpr_view().concat(s); }
-
-    /// @brief Join key expression with another key expression, inserting a separator between them
-    /// @param v the key expression to join with
-    /// @return Newly allocated key expression ``zenoh::KeyExpr``
-    /// @note zenoh-c only
-    z::KeyExpr join(const z::KeyExprView& v) const { return as_keyexpr_view().join(v); }
-#endif
-    /// @brief Checks if the key expression is equal to another key expression
-    /// @param v Another key expression
-    /// @param error Error code if the operation fails
-    /// @return true the key expression is equal to the other key expression
-    bool equals(const z::KeyExprView& v, ErrNo& error) const { return as_keyexpr_view().equals(v, error); }
-
-    /// @brief Checks if the key expression is equal to another key expression
-    /// @param v Another key expression
-    /// @return true the key expression is equal to the other key expression
-    bool equals(const z::KeyExprView& v) const { return as_keyexpr_view().equals(v); }
-
-    /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
-    /// expression contains the set defined by the other key expression
-    /// @param v Another key expression
-    /// @param error Error code if the operation fails
-    /// @return true the key expression includes the other key expression
-    bool includes(const z::KeyExprView& v, ErrNo& error) const { return as_keyexpr_view().includes(v, error); }
-
-    /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
-    /// expression contains the set defined by the other key expression
-    /// @param v Another key expression
-    /// @return true the key expression includes the other key expression
-    bool includes(const z::KeyExprView& v) const { return as_keyexpr_view().includes(v); }
-
-    /// @brief Checks if the key expression intersects another key expression, i.e.
-    /// if the set defined by the key expression intersects the set defined by the other key expression
-    /// @param v Another key expression
-    /// @param error Error code if the operation fails
-    /// @return true the key expression intersects the other key expression
-    bool intersects(const z::KeyExprView& v, ErrNo& error) const { return as_keyexpr_view().intersects(v, error); }
-
-    /// @brief Checks if the key expression intersects another key expression, i.e.
-    /// if the set defined by the key expression intersects the set defined by the other key expression
-    /// @param v Another key expression
-    /// @return true the key expression intersects the other key expression
-    bool intersects(const z::KeyExprView& v) const { return as_keyexpr_view().intersects(v); }
 
     /// @name Operators
 

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -429,6 +429,8 @@ inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b,
 inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b);
 
 /// The non-owning read-only view to a key expression in Zenoh.
+/// See details about key expression syntax in the <a
+/// href="https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Key%20Expressions.md"> Key Expressions RFC</a>.
 struct KeyExprView : public Copyable<::z_keyexpr_t> {
     using Copyable::Copyable;
 
@@ -1370,7 +1372,9 @@ class Str : public Owned<::z_owned_str_t> {
     bool operator==(const char* s) const { return std::string_view(s) == c_str(); }
 };
 
-/// Owned key expression
+/// Owned key expression.
+/// See details about key expression syntax in the <a
+/// href="https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Key%20Expressions.md"> Key Expressions RFC</a>.
 class KeyExpr : public Owned<::z_owned_keyexpr_t> {
    public:
     using Owned::Owned;

--- a/include/zenohcxx/impl.hxx
+++ b/include/zenohcxx/impl.hxx
@@ -63,33 +63,33 @@ inline bool _split_ret_to_bool_and_err(int8_t ret, ErrNo& error) {
     }
 }
 
-inline bool z::KeyExprView::equals(const z::KeyExprView& v, ErrNo& error) const {
-    return z::_split_ret_to_bool_and_err(::z_keyexpr_equals(*this, v), error);
+inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
+    return z::_split_ret_to_bool_and_err(::z_keyexpr_equals(a, b), error);
 }
-inline bool z::KeyExprView::equals(const z::KeyExprView& v) const {
+inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b) {
     ErrNo error;
-    return equals(v, error);
+    return z::keyexpr_equals(a, b, error);
 }
-inline bool z::KeyExprView::includes(const z::KeyExprView& v, ErrNo& error) const {
-    return z::_split_ret_to_bool_and_err(::z_keyexpr_includes(*this, v), error);
+inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
+    return z::_split_ret_to_bool_and_err(::z_keyexpr_includes(a, b), error);
 }
-inline bool z::KeyExprView::includes(const z::KeyExprView& v) const {
+inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b) {
     ErrNo error;
-    return includes(v, error);
+    return z::keyexpr_includes(a, b, error);
 }
-inline bool z::KeyExprView::intersects(const z::KeyExprView& v, ErrNo& error) const {
-    return z::_split_ret_to_bool_and_err(::z_keyexpr_intersects(*this, v), error);
+inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
+    return z::_split_ret_to_bool_and_err(::z_keyexpr_intersects(a, b), error);
 }
-inline bool z::KeyExprView::intersects(const z::KeyExprView& v) const {
+inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b) {
     ErrNo error;
-    return includes(v, error);
+    return z::keyexpr_intersects(a, b, error);
 }
 
 #ifdef __ZENOHCXX_ZENOHC
-inline z::KeyExpr z::KeyExprView::concat(const std::string_view& s) const {
-    return ::z_keyexpr_concat(*this, s.data(), s.length());
+inline z::KeyExpr keyexpr_concat(const z::KeyExprView& k, const std::string_view& s) {
+    return ::z_keyexpr_concat(k, s.data(), s.length());
 }
-inline z::KeyExpr z::KeyExprView::join(const z::KeyExprView& v) const { return ::z_keyexpr_join(*this, v); }
+inline z::KeyExpr keyexpr_join(const z::KeyExprView& a, const z::KeyExprView& b) { return ::z_keyexpr_join(a, b); }
 #endif
 
 inline bool keyexpr_canonize(std::string& s, ErrNo& error) {

--- a/include/zenohcxx/impl.hxx
+++ b/include/zenohcxx/impl.hxx
@@ -92,6 +92,54 @@ inline z::KeyExpr keyexpr_concat(const z::KeyExprView& k, const std::string_view
 inline z::KeyExpr keyexpr_join(const z::KeyExprView& a, const z::KeyExprView& b) { return ::z_keyexpr_join(a, b); }
 #endif
 
+inline bool z::KeyExprView::equals(const z::KeyExprView& other, ErrNo& error) const {
+    return z::keyexpr_equals(*this, other, error);
+}
+
+inline bool z::KeyExprView::equals(const z::KeyExprView& other) const { return z::keyexpr_equals(*this, other); }
+
+inline bool z::KeyExprView::includes(const z::KeyExprView& other, ErrNo& error) const {
+    return z::keyexpr_includes(*this, other, error);
+}
+
+inline bool z::KeyExprView::includes(const z::KeyExprView& other) const { return z::keyexpr_includes(*this, other); }
+
+inline bool z::KeyExprView::intersects(const z::KeyExprView& other, ErrNo& error) const {
+    return z::keyexpr_intersects(*this, other, error);
+}
+
+inline bool z::KeyExprView::intersects(const z::KeyExprView& other) const {
+    return z::keyexpr_intersects(*this, other);
+}
+
+inline bool z::KeyExpr::equals(const z::KeyExprView& other, ErrNo& error) const {
+    return z::keyexpr_equals(*this, other, error);
+}
+
+inline bool z::KeyExpr::equals(const z::KeyExprView& other) const { return z::keyexpr_equals(*this, other); }
+
+inline bool z::KeyExpr::includes(const z::KeyExprView& other, ErrNo& error) const {
+    return z::keyexpr_includes(*this, other, error);
+}
+
+inline bool z::KeyExpr::includes(const z::KeyExprView& other) const { return z::keyexpr_includes(*this, other); }
+
+inline bool z::KeyExpr::intersects(const z::KeyExprView& other, ErrNo& error) const {
+    return z::keyexpr_intersects(*this, other, error);
+}
+
+inline bool z::KeyExpr::intersects(const z::KeyExprView& other) const { return z::keyexpr_intersects(*this, other); }
+
+#ifdef __ZENOHCXX_ZENOHC
+inline z::KeyExpr z::KeyExprView::concat(const std::string_view& s) const { return z::keyexpr_concat(*this, s); }
+
+inline z::KeyExpr z::KeyExpr::concat(const std::string_view& s) const { return z::keyexpr_concat(*this, s); }
+
+inline z::KeyExpr z::KeyExprView::join(const z::KeyExprView& other) const { return z::keyexpr_join(*this, other); }
+
+inline z::KeyExpr z::KeyExpr::join(const z::KeyExprView& other) const { return z::keyexpr_join(*this, other); }
+#endif
+
 inline bool keyexpr_canonize(std::string& s, ErrNo& error) {
     uintptr_t len = s.length();
     error = ::z_keyexpr_canonize(&s[0], &len);

--- a/tests/universal/keyexpr.cxx
+++ b/tests/universal/keyexpr.cxx
@@ -90,6 +90,14 @@ void canonize() {
 
 void concat() {
 #ifdef ZENOHCXX_ZENOHC
+    KeyExprView foov("FOO");
+    auto foobar = foov.concat("BAR");
+    assert(foobar == "FOOBAR");
+
+    KeyExpr foo("FOO");
+    auto foobar1 = foo.concat("BAR");
+    assert(foobar1 == "FOOBAR");
+
     assert(keyexpr_concat("FOO", "BAR") == "FOOBAR");
     assert(keyexpr_concat(KeyExpr("FOO"), "BAR") == "FOOBAR");
     assert(keyexpr_concat(KeyExprView("FOO"), "BAR") == "FOOBAR");
@@ -98,6 +106,14 @@ void concat() {
 
 void join() {
 #ifdef ZENOHCXX_ZENOHC
+    KeyExprView foov("FOO");
+    auto foobar = foov.concat("BAR");
+    assert(foobar == "FOO/BAR");
+
+    KeyExpr foo("FOO");
+    auto foobar1 = foo.concat("BAR");
+    assert(foobar1 == "FOO/BAR");
+
     assert(keyexpr_join("FOO", "BAR") == "FOO/BAR");
     assert(keyexpr_join(KeyExpr("FOO"), "BAR") == "FOO/BAR");
     assert(keyexpr_join(KeyExprView("FOO"), "BAR") == "FOO/BAR");
@@ -114,13 +130,48 @@ void equals() {
     KeyExprView nul(nullptr);
     ErrNo err;
 
+    KeyExpr foo("FOO");
+    KeyExprView foov("FOO");
+    KeyExpr bar("BAR");
+    KeyExprView barv("BAR");
+
+    assert(foo.equals(foo));
+    assert(foo.equals(foo, err));
+    assert(err == 0);
+    assert(foo.equals(foov));
+    assert(foo.equals(foov, err));
+    assert(err == 0);
+    assert(foov.equals(foo));
+    assert(foov.equals(foo, err));
+    assert(err == 0);
+    assert(foov.equals(foov));
+    assert(foov.equals(foov, err));
+
     assert(keyexpr_equals("FOO", "FOO"));
     assert(keyexpr_equals("FOO", "FOO", err));
     assert(err == 0);
 
+    assert(!foo.equals(bar));
+    assert(!foo.equals(bar, err));
+    assert(err == 0);
+    assert(!foo.equals(barv));
+    assert(!foo.equals(barv, err));
+    assert(err == 0);
+    assert(!foov.equals(bar));
+    assert(!foov.equals(bar, err));
+    assert(err == 0);
+    assert(!foov.equals(barv));
+    assert(!foov.equals(barv, err));
+
     assert(!keyexpr_equals("FOO", "BAR"));
     assert(!keyexpr_equals("FOO", "BAR", err));
     assert(err == 0);
+
+    assert(!foo.equals(nul));
+    assert(!foo.equals(nul, err));
+    assert(err < 0);
+    assert(!foov.equals(nul));
+    assert(!foov.equals(nul, err));
 
     assert(!keyexpr_equals("FOO", nul));
     assert(!keyexpr_equals("FOO", nul, err));
@@ -131,9 +182,28 @@ void includes() {
     KeyExprView nul(nullptr);
     ErrNo err;
 
+    KeyExprView foostarv("FOO/*");
+    KeyExprView foobarv("FOO/BAR");
+    assert(foostarv.includes(foobarv));
+    assert(foostarv.includes(foobarv, err));
+    assert(!foobarv.includes(foostarv));
+    assert(!foobarv.includes(foostarv, err));
+    assert(!foostarv.includes(nul));
+    assert(!foostarv.includes(nul, err));
+
     assert(keyexpr_includes("FOO/*", "FOO/BAR"));
     assert(keyexpr_includes("FOO/*", "FOO/BAR", err));
     assert(err == 0);
+
+    KeyExpr foostar("FOO/*");
+    KeyExpr foobar("FOO/BAR");
+    assert(foostar.includes(foobar));
+    assert(foostar.includes(foobar, err));
+    assert(!foobar.includes(foostar));
+    assert(!foobar.includes(foostar, err));
+    assert(!foostar.includes(nul));
+    assert(!foostar.includes(nul, err));
+    assert(err < 0);
 
     assert(!keyexpr_includes("FOO/BAR", "FOO/*"));
     assert(!keyexpr_includes("FOO/BAR", "FOO/*", err));
@@ -144,8 +214,8 @@ void includes() {
     assert(err < 0);
 
     KeyExpr foo("FOO");
-    assert(keyexpr_includes(foo, "FOO/BAR"));
-    assert(keyexpr_includes(foo, "FOO/BAR", err));
+    assert(!keyexpr_includes(foo, "FOO/BAR"));
+    assert(!keyexpr_includes(foo, "FOO/BAR", err));
     assert(err == 0);
     assert(!keyexpr_includes("FOO/BAR", foo));
     assert(!keyexpr_includes("FOO/BAR", foo, err));
@@ -155,6 +225,17 @@ void includes() {
 void intersects() {
     KeyExprView nul(nullptr);
     ErrNo err;
+
+    KeyExprView foostarv("FOO/*");
+    KeyExprView foobarv("FOO/BAR");
+    KeyExprView starbuzv("*/BUZ");
+    assert(foostarv.intersects(foobarv));
+    assert(!starbuzv.intersects(foobarv));
+    assert(!foostarv.intersects(nul));
+    assert(foostarv.intersects(foobarv, err));
+    assert(!starbuzv.intersects(foobarv, err));
+    assert(!foostarv.intersects(nul, err));
+    assert(err != 0);
 
     assert(keyexpr_intersects("FOO/*", "FOO/BAR"));
     assert(keyexpr_intersects("FOO/*", "FOO/BAR", err));
@@ -168,7 +249,18 @@ void intersects() {
     assert(!keyexpr_intersects("FOO/*", nul, err));
     assert(err < 0);
 
+    KeyExpr foostar("FOO/*");
     KeyExpr foobar("FOO/BAR");
+    KeyExpr starbuz("*/BUZ");
+    assert(foostar.intersects(foobar));
+    assert(!starbuz.intersects(foobar));
+    assert(!foostar.intersects(nul));
+    assert(foostar.intersects(foobar, err));
+    assert(err == 0);
+    assert(!starbuz.intersects(foobar, err));
+    assert(!foostar.intersects(nul, err));
+    assert(err != 0);
+
     assert(keyexpr_intersects("FOO/*", foobar));
     assert(keyexpr_intersects("FOO/*", foobar, err));
     assert(err == 0);

--- a/tests/universal/keyexpr.cxx
+++ b/tests/universal/keyexpr.cxx
@@ -142,6 +142,14 @@ void includes() {
     assert(!keyexpr_includes("FOO/*", nul));
     assert(!keyexpr_includes("FOO/*", nul, err));
     assert(err < 0);
+
+    KeyExpr foo("FOO");
+    assert(keyexpr_includes(foo, "FOO/BAR"));
+    assert(keyexpr_includes(foo, "FOO/BAR", err));
+    assert(err == 0);
+    assert(!keyexpr_includes("FOO/BAR", foo));
+    assert(!keyexpr_includes("FOO/BAR", foo, err));
+    assert(err == 0);
 }
 
 void intersects() {
@@ -159,6 +167,11 @@ void intersects() {
     assert(!keyexpr_intersects("FOO/*", nul));
     assert(!keyexpr_intersects("FOO/*", nul, err));
     assert(err < 0);
+
+    KeyExpr foobar("FOO/BAR");
+    assert(keyexpr_intersects("FOO/*", foobar));
+    assert(keyexpr_intersects("FOO/*", foobar, err));
+    assert(err == 0);
 }
 
 #include <variant>

--- a/tests/universal/keyexpr.cxx
+++ b/tests/universal/keyexpr.cxx
@@ -90,25 +90,23 @@ void canonize() {
 
 void concat() {
 #ifdef ZENOHCXX_ZENOHC
-    KeyExprView foov("FOO");
-    auto foobar = foov.concat("BAR");
-    assert(foobar == "FOOBAR");
-
-    KeyExpr foo("FOO");
-    auto foobar1 = foo.concat("BAR");
-    assert(foobar1 == "FOOBAR");
+    assert(keyexpr_concat("FOO", "BAR") == "FOOBAR");
+    assert(keyexpr_concat(KeyExpr("FOO"), "BAR") == "FOOBAR");
+    assert(keyexpr_concat(KeyExprView("FOO"), "BAR") == "FOOBAR");
 #endif
 }
 
 void join() {
 #ifdef ZENOHCXX_ZENOHC
-    KeyExprView foov("FOO");
-    auto foobar = foov.concat("BAR");
-    assert(foobar == "FOO/BAR");
-
-    KeyExpr foo("FOO");
-    auto foobar1 = foo.concat("BAR");
-    assert(foobar1 == "FOO/BAR");
+    assert(keyexpr_join("FOO", "BAR") == "FOO/BAR");
+    assert(keyexpr_join(KeyExpr("FOO"), "BAR") == "FOO/BAR");
+    assert(keyexpr_join(KeyExprView("FOO"), "BAR") == "FOO/BAR");
+    assert(keyexpr_join("FOO", KeyExpr("BAR")) == "FOO/BAR");
+    assert(keyexpr_join(KeyExpr("FOO"), KeyExpr("BAR")) == "FOO/BAR");
+    assert(keyexpr_join(KeyExprView("FOO"), KeyExpr("BAR")) == "FOO/BAR");
+    assert(keyexpr_join("FOO", KeyExprView("BAR")) == "FOO/BAR");
+    assert(keyexpr_join(KeyExpr("FOO"), KeyExprView("BAR")) == "FOO/BAR");
+    assert(keyexpr_join(KeyExprView("FOO"), KeyExprView("BAR")) == "FOO/BAR");
 #endif
 }
 
@@ -116,43 +114,16 @@ void equals() {
     KeyExprView nul(nullptr);
     ErrNo err;
 
-    KeyExpr foo("FOO");
-    KeyExprView foov("FOO");
-    KeyExpr bar("BAR");
-    KeyExprView barv("BAR");
-
-    assert(foo.equals(foo));
-    assert(foo.equals(foo, err));
-    assert(err == 0);
-    assert(foo.equals(foov));
-    assert(foo.equals(foov, err));
-    assert(err == 0);
-    assert(foov.equals(foo));
-    assert(foov.equals(foo, err));
-    assert(err == 0);
-    assert(foov.equals(foov));
-    assert(foov.equals(foov, err));
+    assert(keyexpr_equals("FOO", "FOO"));
+    assert(keyexpr_equals("FOO", "FOO", err));
     assert(err == 0);
 
-    assert(!foo.equals(bar));
-    assert(!foo.equals(bar, err));
-    assert(err == 0);
-    assert(!foo.equals(barv));
-    assert(!foo.equals(barv, err));
-    assert(err == 0);
-    assert(!foov.equals(bar));
-    assert(!foov.equals(bar, err));
-    assert(err == 0);
-    assert(!foov.equals(barv));
-    assert(!foov.equals(barv, err));
+    assert(!keyexpr_equals("FOO", "BAR"));
+    assert(!keyexpr_equals("FOO", "BAR", err));
     assert(err == 0);
 
-    assert(!foo.equals(nul));
-    assert(!foo.equals(nul, err));
-    assert(err < 0);
-
-    assert(!foov.equals(nul));
-    assert(!foov.equals(nul, err));
+    assert(!keyexpr_equals("FOO", nul));
+    assert(!keyexpr_equals("FOO", nul, err));
     assert(err < 0);
 }
 
@@ -160,28 +131,16 @@ void includes() {
     KeyExprView nul(nullptr);
     ErrNo err;
 
-    KeyExprView foostarv("FOO/*");
-    KeyExprView foobarv("FOO/BAR");
-    assert(foostarv.includes(foobarv));
-    assert(foostarv.includes(foobarv, err));
+    assert(keyexpr_includes("FOO/*", "FOO/BAR"));
+    assert(keyexpr_includes("FOO/*", "FOO/BAR", err));
     assert(err == 0);
-    assert(!foobarv.includes(foostarv));
-    assert(!foobarv.includes(foostarv, err));
-    assert(err == 0);
-    assert(!foostarv.includes(nul));
-    assert(!foostarv.includes(nul, err));
-    assert(err < 0);
 
-    KeyExpr foostar("FOO/*");
-    KeyExpr foobar("FOO/BAR");
-    assert(foostar.includes(foobar));
-    assert(foostar.includes(foobar, err));
+    assert(!keyexpr_includes("FOO/BAR", "FOO/*"));
+    assert(!keyexpr_includes("FOO/BAR", "FOO/*", err));
     assert(err == 0);
-    assert(!foobar.includes(foostar));
-    assert(!foobar.includes(foostar, err));
-    assert(err == 0);
-    assert(!foostar.includes(nul));
-    assert(!foostar.includes(nul, err));
+
+    assert(!keyexpr_includes("FOO/*", nul));
+    assert(!keyexpr_includes("FOO/*", nul, err));
     assert(err < 0);
 }
 
@@ -189,31 +148,17 @@ void intersects() {
     KeyExprView nul(nullptr);
     ErrNo err;
 
-    KeyExprView foostarv("FOO/*");
-    KeyExprView foobarv("FOO/BAR");
-    KeyExprView starbuzv("*/BUZ");
-    assert(foostarv.intersects(foobarv));
-    assert(!starbuzv.intersects(foobarv));
-    assert(!foostarv.intersects(nul));
-    assert(foostarv.intersects(foobarv, err));
+    assert(keyexpr_intersects("FOO/*", "FOO/BAR"));
+    assert(keyexpr_intersects("FOO/*", "FOO/BAR", err));
     assert(err == 0);
-    assert(!starbuzv.intersects(foobarv, err));
-    assert(err == 0);
-    assert(!foostarv.intersects(nul, err));
-    assert(err != 0);
 
-    KeyExpr foostar("FOO/*");
-    KeyExpr foobar("FOO/BAR");
-    KeyExpr starbuz("*/BUZ");
-    assert(foostar.intersects(foobar));
-    assert(!starbuz.intersects(foobar));
-    assert(!foostar.intersects(nul));
-    assert(foostar.intersects(foobar, err));
+    assert(!keyexpr_intersects("*/BUZ", "FOO/BAR"));
+    assert(!keyexpr_intersects("*/BUZ", "FOO/BAR", err));
     assert(err == 0);
-    assert(!starbuz.intersects(foobar, err));
-    assert(err == 0);
-    assert(!foostar.intersects(nul, err));
-    assert(err != 0);
+
+    assert(!keyexpr_intersects("FOO/*", nul));
+    assert(!keyexpr_intersects("FOO/*", nul, err));
+    assert(err < 0);
 }
 
 #include <variant>


### PR DESCRIPTION
proposed fix for https://github.com/eclipse-zenoh/zenoh-cpp/issues/63