### PR TITLE
forbid use of keyexpr compare funcitons without error check for zenohpico, session-based comared functions added

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -67,21 +67,6 @@ function(debug_print var)
 endfunction()
 
 #
-# Add default set of libraries depending on platform
-#
-function(add_platform_libraries target)
-	if(APPLE)
-		find_library(FFoundation Foundation)
-		find_library(FSecurity Security)
-		target_link_libraries(${target} PUBLIC ${FFoundation} ${FSecurity})
-	elseif(UNIX)
-		target_link_libraries(${target} PUBLIC rt pthread m dl)
-	elseif(WIN32)
-		target_link_libraries(${target} PUBLIC ws2_32 crypt32 secur32 bcrypt ncrypt userenv ntdll iphlpapi runtimeobject)
-	endif()
-endfunction()
-
-#
 # Copy necessary dlls to target runtime directory
 #
 function(copy_dlls target)

--- a/docs/keyexpr.rst
+++ b/docs/keyexpr.rst
@@ -15,33 +15,45 @@
 Key Expressions
 ===============
 
-Classes implementing key expressions. See `zenoh abstractions`_ for details.
+Classes and functions for processing key expressions. See `zenoh abstractions`_ for detailed explanation of key expression concept.
+
+Key expression can be registered in the :cpp:class:`zenoh::Session` object with :cpp:func:`zenoh::Session::declare_keyexpr` method. The unique id is internally assinged to the key expression string in this case.
+
+There is a subtle difference between zenoh-c and zenoh-pico implementations of key expressions which affects the key expression API.
+In the zenoh-c the key expresssion structure stores both the assigned id and the original key expression string.
+On the contrary, for declared key expressions the zenoh-pico keeps only the unique id in the key expression instance. The string
+representation is avaliable through the :cpp:func:`zenoh::KeyExprView::resolve` method only, which accesses the :cpp:class:`zenoh::Session` instance.
+
+Therefore in zenoh-pico case the text compare operations between the :cpp:class:`KeyExprView` objects will return error result for declared key expressions.
+
+For that reason the operations without explicit error handling are disabled for zenoh-pico.
+The methods which automatically performs the necessary resolving are provided instead: :cpp:func:`zenoh::Session::keyexpr_equals`, :cpp:func:`zenoh::Session::keyexpr_includes`, :cpp:func:`zenoh::Session::keyexpr_intersects`.
 
 .. _`zenoh abstractions`: https://zenoh.io/docs/manual/abstractions/
 
-.. doxygenfunction:: keyexpr_canonize(std::string& s, ErrNo& error)
+.. doxygenfunction:: zenoh::keyexpr_canonize(std::string& s, ErrNo& error)
 
-.. doxygenfunction:: keyexpr_canonize(std::string& s)
+.. doxygenfunction:: zenoh::keyexpr_canonize(std::string& s)
 
-.. doxygenfunction:: keyexpr_is_canon(const std::string_view& s, ErrNo& error)
+.. doxygenfunction:: zenoh::keyexpr_is_canon(const std::string_view& s, ErrNo& error)
 
-.. doxygenfunction:: keyexpr_is_canon(const std::string_view& s)
+.. doxygenfunction:: zenoh::keyexpr_is_canon(const std::string_view& s)
 
-.. doxygenfunction:: keyexpr_concat(const zenoh::KeyExprView& k, const std::string_view& s)
+.. doxygenfunction:: zenoh::keyexpr_concat(const zenoh::KeyExprView& k, const std::string_view& s)
 
-.. doxygenfunction:: keyexpr_join(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
+.. doxygenfunction:: zenoh::keyexpr_join(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
 
-.. doxygenfunction:: keyexpr_equals(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
+.. doxygenfunction:: zenoh::keyexpr_equals(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
 
-.. doxygenfunction:: keyexpr_equals(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
+.. doxygenfunction:: zenoh::keyexpr_equals(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
 
-.. doxygenfunction:: keyexpr_includes(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
+.. doxygenfunction:: zenoh::keyexpr_includes(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
 
-.. doxygenfunction:: keyexpr_includes(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
+.. doxygenfunction:: zenoh::keyexpr_includes(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
 
-.. doxygenfunction:: keyexpr_intersects(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
+.. doxygenfunction:: zenoh::keyexpr_intersects(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b, ErrNo& error)
 
-.. doxygenfunction:: keyexpr_intersects(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
+.. doxygenfunction:: zenoh::keyexpr_intersects(const zenoh::KeyExprView& a, const zenoh::KeyExprView& b)
 
 .. doxygenstruct:: zenoh::KeyExprUnchecked
    :members:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,7 +30,6 @@ function(add_example file mode lib)
     target_link_libraries(${target} PUBLIC ${lib})
 	set_property(TARGET ${target} PROPERTY LANGUAGE CXX)
 	set_property(TARGET ${target} PROPERTY CXX_STANDARD 17)
-	add_platform_libraries(${target})
 endfunction()
 
 function(add_examples glob mode lib)

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -404,29 +404,27 @@ inline bool keyexpr_is_canon(const std::string_view& s);
 
 #ifdef __ZENOHCXX_ZENOHC
 /// @brief Concatenate the key expression and a string
+/// @param k the key expression
 /// @param s ``std::string_view`` representing a key expression
 /// @return Newly allocated key expression ``zenoh::KeyExpr``
 /// @note zenoh-c only
 inline z::KeyExpr keyexpr_concat(const z::KeyExprView& k, const std::string_view& s);
 
-/// @brief Join key expression with another key expression, inserting a separator between them
-/// @param v the key expression to join with
+/// @brief Join two key expressions, inserting a separator between them
+/// @param a Key expression
+/// @param b Key expressio
 /// @return Newly allocated key expression ``zenoh::KeyExpr``
 /// @note zenoh-c only
 inline z::KeyExpr keyexpr_join(const z::KeyExprView& a, const z::KeyExprView& b);
 #endif
 
-/// @brief Checks if the key expression is equal to another key expression
-/// @param v Another key expression
+/// @brief Checks if the two key expressions are equal
+/// @param a Key expression
+/// @param b Key expression
 /// @param error Error code returned by ``::z_keyexpr_equals`` (value < -1 if any of the key expressions is not
 /// valid)
-/// @return true the key expression is equal to the other key expression
+/// @return true the key expressions are equal
 inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
-
-/// @brief Checks if the key expression is equal to another key expression
-/// @param v Another key expression
-/// @return true the key expression is equal to the other key expression
-inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b);
 
 /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
 /// expression contains the set defined by the other key expression
@@ -435,6 +433,21 @@ inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b);
 /// valid)
 /// @return true the key expression includes the other key expression
 inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
+
+/// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
+/// which is contained in both of the sets defined by the key expressions
+/// @param v Another key expression
+/// @param error Error code returned by ``::z_keyexpr_intersects`` (value < -1 if any of the key expressions is not
+/// valid)
+/// @return true the key expression intersects with the other key expression
+inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
+
+#ifdef __ZENOHCXX_ZENOHC
+/// @brief Checks if the two key expressions are equal
+/// @param a Key expression
+/// @param b Key expression
+/// @return true the key expressions are equal
+inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b);
 
 /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
 /// expression contains the set defined by the other key expression
@@ -445,16 +458,9 @@ inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b);
 /// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
 /// which is contained in both of the sets defined by the key expressions
 /// @param v Another key expression
-/// @param error Error code returned by ``::z_keyexpr_intersects`` (value < -1 if any of the key expressions is not
-/// valid)
-/// @return true the key expression intersects with the other key expression
-inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
-
-/// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
-/// which is contained in both of the sets defined by the key expressions
-/// @param v Another key expression
 /// @return true the key expression intersects with the other key expression
 inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b);
+#endif
 
 /// The non-owning read-only view to a key expression in Zenoh.
 struct KeyExprView : public Copyable<::z_keyexpr_t> {
@@ -532,25 +538,25 @@ struct KeyExprView : public Copyable<::z_keyexpr_t> {
     /// @brief see ``zenoh::keyexpr_join``
     /// @note zenoh-c only
     z::KeyExpr join(const z::KeyExprView& v) const;
-#endif
-
-    /// @brief see ``zenoh::keyexpr_equals``
-    bool equals(const z::KeyExprView& v, ErrNo& error) const;
 
     /// @brief see ``zenoh::keyexpr_equals``
     bool equals(const z::KeyExprView& v) const;
 
     /// @brief see ``zenoh::keyexpr_includes``
-    bool includes(const z::KeyExprView& v, ErrNo& error) const;
-
-    /// @brief see ``zenoh::keyexpr_includes``
     bool includes(const z::KeyExprView& v) const;
 
     /// @brief see ``zenoh::keyexpr_intersects``
-    bool intersects(const z::KeyExprView& v, ErrNo& error) const;
+    bool intersects(const z::KeyExprView& v) const;
+#endif
+
+    /// @brief see ``zenoh::keyexpr_equals``
+    bool equals(const z::KeyExprView& v, ErrNo& error) const;
+
+    /// @brief see ``zenoh::keyexpr_includes``
+    bool includes(const z::KeyExprView& v, ErrNo& error) const;
 
     /// @brief see ``zenoh::keyexpr_intersects``
-    bool intersects(const z::KeyExprView& v) const;
+    bool intersects(const z::KeyExprView& v, ErrNo& error) const;
 };
 
 /// The encoding of a payload, in a MIME-like format.
@@ -1420,25 +1426,25 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     /// @brief see ``zenoh::keyexpr_join``
     /// @note zenoh-c only
     z::KeyExpr join(const z::KeyExprView& v) const;
-#endif
-
-    /// @brief see ``zenoh::keyexpr_equals``
-    bool equals(const z::KeyExprView& v, ErrNo& error) const;
 
     /// @brief see ``zenoh::keyexpr_equals``
     bool equals(const z::KeyExprView& v) const;
 
     /// @brief see ``zenoh::keyexpr_includes``
-    bool includes(const z::KeyExprView& v, ErrNo& error) const;
-
-    /// @brief see ``zenoh::keyexpr_includes``
     bool includes(const z::KeyExprView& v) const;
 
     /// @brief see ``zenoh::keyexpr_intersects``
-    bool intersects(const z::KeyExprView& v, ErrNo& error) const;
+    bool intersects(const z::KeyExprView& v) const;
+#endif
+
+    /// @brief see ``zenoh::keyexpr_equals``
+    bool equals(const z::KeyExprView& v, ErrNo& error) const;
+
+    /// @brief see ``zenoh::keyexpr_includes``
+    bool includes(const z::KeyExprView& v, ErrNo& error) const;
 
     /// @brief see ``zenoh::keyexpr_intersects``
-    bool intersects(const z::KeyExprView& v) const;
+    bool intersects(const z::KeyExprView& v, ErrNo& error) const;
 };
 
 class ScoutingConfig;
@@ -2078,6 +2084,70 @@ class Session : public Owned<::z_owned_session_t> {
     /// @return true if the join procedure was executed successfully, false otherwise.
     bool send_join(ErrNo& error);
 #endif
+
+#ifdef __ZENOHCXX_ZENOHC
+    /// @brief Concatenate the key expression and a string, resolving them if necessary
+    /// @param k the key expression
+    /// @param s ``std::string_view`` representing a key expression
+    /// @return Newly allocated key expression ``zenoh::KeyExpr``
+    /// @note zenoh-c only
+    z::KeyExpr keyexpr_concat(const z::KeyExprView& k, const std::string_view& s);
+
+    /// @brief Join two key expressions, inserting a separator between them
+    /// @param a Key expression
+    /// @param b Key expressio
+    /// @return Newly allocated key expression ``zenoh::KeyExpr``
+    /// @note zenoh-c only
+    z::KeyExpr keyexpr_join(const z::KeyExprView& a, const z::KeyExprView& b);
+#endif
+
+    /// @brief Checks if the two key expressions are equal, resolving them if necessary
+    /// @param a Key expression
+    /// @param b Key expression
+    /// @param error Error code returned by ``::z_keyexpr_equals`` (value < -1 if any of the key expressions is not
+    /// valid)
+    /// @return true the key expressions are equal
+    bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
+
+    /// @brief Checks if the two key expressions are equal, resolving them if necessary
+    /// @param a Key expression
+    /// @param b Key expression
+    /// @return true the key expressions are equal
+    bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b);
+
+    /// @brief Checks if the key expression "a" includes expression "b", resolving them if necessary.
+    // "Includes" means that the set defined by the key expression contains the set defined by the other key expression
+    /// @param a Key expression
+    /// @param b Key expression
+    /// @param error Error code returned by ``::z_keyexpr_includes`` (value < -1 if any of the key expressions is not
+    /// valid)
+    /// @return true the key expression includes the other key expression
+    bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
+
+    /// @brief Checks if the key expression "a" includes key expression "b", resolving them if necessary.
+    // "Includes" means that the set defined by the key expression contains the set defined by the other key expression
+    /// @param a Key expression
+    /// @param b Key expression
+    /// @return true the key expression includes the other key expression
+    bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b);
+
+    /// @brief Checks if the key expression intersects with another key expression, resolving them if necessaRY.
+    /// "Intersects" means that exists at least one key which is contained in both of the sets defined by the key
+    /// expressions
+    /// @param a Key expression
+    /// @param b Key expression
+    /// @param error Error code returned by ``::z_keyexpr_intersects`` (value < -1 if any of the key expressions is not
+    /// valid)
+    /// @return true the key expression intersects with the other key expression
+    bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error);
+
+    /// @brief Checks if the key expression intersects with another key expression, resolving them if necessaRY.
+    /// "Intersects" means that exists at least one key which is contained in both of the sets defined by the key
+    /// expressions
+    /// @param a Key expression
+    /// @param b Key expression
+    /// @return true the key expression intersects with the other key expression
+    bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b);
 
    private:
     Session(z::Config&& v) : Owned(_z_open(std::move(v))) {}

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -343,6 +343,34 @@ struct HelloView : public Copyable<::z_hello_t> {
     const z::StrArrayView& get_locators() const { return static_cast<const z::StrArrayView&>(locators); }
 };
 
+/// Owned string returned from zenoh. It is automatically freed when the object is destroyed.
+class Str : public Owned<::z_owned_str_t> {
+   public:
+    using Owned::Owned;
+
+    /// @name Methods
+
+    /// @brief Get the string value
+    /// @return ``const char*`` null-terminated string pointer
+    const char* c_str() const { return loan(); }
+
+    /// @name Operators
+
+    /// @brief Get the string value
+    /// @return ``const char*`` null-terminated string pointer
+    operator const char*() const { return loan(); }
+
+    /// @brief Equality operator
+    /// @param s the ``std::string_view`` to compare with
+    /// @return true if the two strings are equal
+    bool operator==(const std::string_view& s) const { return s == c_str(); }
+
+    /// @brief Equality operator
+    /// @param s the null-terminated string to compare with
+    /// @return true if the two strings are equal
+    bool operator==(const char* s) const { return std::string_view(s) == c_str(); }
+};
+
 class KeyExpr;
 class KeyExprView;
 
@@ -488,6 +516,10 @@ struct KeyExprView : public Copyable<::z_keyexpr_t> {
     /// @brief Return the key expression as a ``std::string_view``
     /// @return ``std::string_view`` representing the key expression
     std::string_view as_string_view() const { return as_bytes().as_string_view(); }
+
+#ifdef __ZENOHCXX_ZENOHPICO
+    z::Str resolve(const z::Session& s) const;
+#endif
 
 #ifdef __ZENOHCXX_ZENOHC
     // operator += purposedly not defined to not provoke ambiguity between concat (which
@@ -1340,34 +1372,6 @@ struct PublisherDeleteOptions : public Copyable<::z_publisher_delete_options_t> 
     /// @param v the other ``PublisherDeleteOptions`` to compare with
     /// @return true if the two values are not equal
     bool operator!=(const z::PublisherOptions& v) const { return !operator==(v); }
-};
-
-/// Owned string returned from zenoh. It is automatically freed when the object is destroyed.
-class Str : public Owned<::z_owned_str_t> {
-   public:
-    using Owned::Owned;
-
-    /// @name Methods
-
-    /// @brief Get the string value
-    /// @return ``const char*`` null-terminated string pointer
-    const char* c_str() const { return loan(); }
-
-    /// @name Operators
-
-    /// @brief Get the string value
-    /// @return ``const char*`` null-terminated string pointer
-    operator const char*() const { return loan(); }
-
-    /// @brief Equality operator
-    /// @param s the ``std::string_view`` to compare with
-    /// @return true if the two strings are equal
-    bool operator==(const std::string_view& s) const { return s == c_str(); }
-
-    /// @brief Equality operator
-    /// @param s the null-terminated string to compare with
-    /// @return true if the two strings are equal
-    bool operator==(const char* s) const { return std::string_view(s) == c_str(); }
 };
 
 /// Owned key expression

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -428,7 +428,8 @@ inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b, Err
 
 /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
 /// expression contains the set defined by the other key expression
-/// @param v Another key expression
+/// @param a Key expression
+/// @param b Key expression
 /// @param error Error code returned by ``::z_keyexpr_includes`` (value < -1 if any of the key expressions is not
 /// valid)
 /// @return true the key expression includes the other key expression
@@ -436,7 +437,8 @@ inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b, E
 
 /// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
 /// which is contained in both of the sets defined by the key expressions
-/// @param v Another key expression
+/// @param a Key expression
+/// @param b Key expression
 /// @param error Error code returned by ``::z_keyexpr_intersects`` (value < -1 if any of the key expressions is not
 /// valid)
 /// @return true the key expression intersects with the other key expression
@@ -451,13 +453,15 @@ inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b);
 
 /// @brief Checks if the key expression includes another key expression, i.e. if the set defined by the key
 /// expression contains the set defined by the other key expression
-/// @param v Another key expression
+/// @param a Key expression
+/// @param b Key expression
 /// @return true the key expression includes the other key expression
 inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b);
 
 /// @brief Checks if the key expression intersects with another key expression, i.e. there exists at least one key
 /// which is contained in both of the sets defined by the key expressions
-/// @param v Another key expression
+/// @param a Key expression
+/// @param b Key expression
 /// @return true the key expression intersects with the other key expression
 inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b);
 #endif
@@ -524,6 +528,10 @@ struct KeyExprView : public Copyable<::z_keyexpr_t> {
     std::string_view as_string_view() const { return as_bytes().as_string_view(); }
 
 #ifdef __ZENOHCXX_ZENOHPICO
+    /// @brief Get string representation for key expression created with ``zenoh::Session::declare_keyexpr``
+    /// @param s ``zenoh::Session`` object
+    /// @return string representation of the key expression
+    /// @note zenoh-pico only
     z::Str resolve(const z::Session& s) const;
 #endif
 

--- a/include/zenohcxx/base.hxx
+++ b/include/zenohcxx/base.hxx
@@ -106,7 +106,7 @@ class Owned {
     bool check() const { return ::z_check(_0); }
 
     /// @brief Get zenoh-c loan structure ``z_XXX_t`` associated with owned object ``z_owned_XXX_t``
-    /// if the corresponding zenoh-c function ``z_loan`` is defined/
+    /// if the corresponding zenoh-c function ``z_loan`` is defined
     /// @return zenoh-c loan structure ``z_XXX_t``
     template <typename ZC_LOAN_TYPE = decltype(::z_loan(*static_cast<const ZC_OWNED_TYPE*>(nullptr)))>
     ZC_LOAN_TYPE loan() const {

--- a/include/zenohcxx/impl.hxx
+++ b/include/zenohcxx/impl.hxx
@@ -72,24 +72,27 @@ inline bool _split_ret_to_bool_and_err(int8_t ret, ErrNo& error) {
 inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
     return z::_split_ret_to_bool_and_err(::z_keyexpr_equals(a, b), error);
 }
+inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
+    return z::_split_ret_to_bool_and_err(::z_keyexpr_includes(a, b), error);
+}
+inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
+    return z::_split_ret_to_bool_and_err(::z_keyexpr_intersects(a, b), error);
+}
+
+#ifdef __ZENOHCXX_ZENOHC
 inline bool keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b) {
     ErrNo error;
     return z::keyexpr_equals(a, b, error);
-}
-inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
-    return z::_split_ret_to_bool_and_err(::z_keyexpr_includes(a, b), error);
 }
 inline bool keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b) {
     ErrNo error;
     return z::keyexpr_includes(a, b, error);
 }
-inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
-    return z::_split_ret_to_bool_and_err(::z_keyexpr_intersects(a, b), error);
-}
 inline bool keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b) {
     ErrNo error;
     return z::keyexpr_intersects(a, b, error);
 }
+#endif
 
 #ifdef __ZENOHCXX_ZENOHC
 inline z::KeyExpr keyexpr_concat(const z::KeyExprView& k, const std::string_view& s) {
@@ -102,48 +105,46 @@ inline bool z::KeyExprView::equals(const z::KeyExprView& other, ErrNo& error) co
     return z::keyexpr_equals(*this, other, error);
 }
 
-inline bool z::KeyExprView::equals(const z::KeyExprView& other) const { return z::keyexpr_equals(*this, other); }
-
 inline bool z::KeyExprView::includes(const z::KeyExprView& other, ErrNo& error) const {
     return z::keyexpr_includes(*this, other, error);
 }
 
-inline bool z::KeyExprView::includes(const z::KeyExprView& other) const { return z::keyexpr_includes(*this, other); }
-
 inline bool z::KeyExprView::intersects(const z::KeyExprView& other, ErrNo& error) const {
     return z::keyexpr_intersects(*this, other, error);
-}
-
-inline bool z::KeyExprView::intersects(const z::KeyExprView& other) const {
-    return z::keyexpr_intersects(*this, other);
 }
 
 inline bool z::KeyExpr::equals(const z::KeyExprView& other, ErrNo& error) const {
     return z::keyexpr_equals(*this, other, error);
 }
 
-inline bool z::KeyExpr::equals(const z::KeyExprView& other) const { return z::keyexpr_equals(*this, other); }
-
 inline bool z::KeyExpr::includes(const z::KeyExprView& other, ErrNo& error) const {
     return z::keyexpr_includes(*this, other, error);
 }
 
-inline bool z::KeyExpr::includes(const z::KeyExprView& other) const { return z::keyexpr_includes(*this, other); }
-
 inline bool z::KeyExpr::intersects(const z::KeyExprView& other, ErrNo& error) const {
     return z::keyexpr_intersects(*this, other, error);
 }
-
-inline bool z::KeyExpr::intersects(const z::KeyExprView& other) const { return z::keyexpr_intersects(*this, other); }
-
 #ifdef __ZENOHCXX_ZENOHC
 inline z::KeyExpr z::KeyExprView::concat(const std::string_view& s) const { return z::keyexpr_concat(*this, s); }
 
-inline z::KeyExpr z::KeyExpr::concat(const std::string_view& s) const { return z::keyexpr_concat(*this, s); }
-
 inline z::KeyExpr z::KeyExprView::join(const z::KeyExprView& other) const { return z::keyexpr_join(*this, other); }
 
+inline bool z::KeyExprView::equals(const z::KeyExprView& other) const { return z::keyexpr_equals(*this, other); }
+
+inline bool z::KeyExprView::includes(const z::KeyExprView& other) const { return z::keyexpr_includes(*this, other); }
+inline bool z::KeyExprView::intersects(const z::KeyExprView& other) const {
+    return z::keyexpr_intersects(*this, other);
+}
+
+inline z::KeyExpr z::KeyExpr::concat(const std::string_view& s) const { return z::keyexpr_concat(*this, s); }
+
 inline z::KeyExpr z::KeyExpr::join(const z::KeyExprView& other) const { return z::keyexpr_join(*this, other); }
+
+inline bool z::KeyExpr::equals(const z::KeyExprView& other) const { return z::keyexpr_equals(*this, other); }
+
+inline bool z::KeyExpr::includes(const z::KeyExprView& other) const { return z::keyexpr_includes(*this, other); }
+
+inline bool z::KeyExpr::intersects(const z::KeyExprView& other) const { return z::keyexpr_intersects(*this, other); }
 #endif
 
 inline bool keyexpr_canonize(std::string& s, ErrNo& error) {
@@ -598,60 +599,113 @@ inline bool z::Config::insert(uint8_t key, const char* value, ErrNo& error) {
 #endif
 
 #ifdef __ZENOHCXX_ZENOHPICO
-inline bool Session::start_read_task() {
+inline bool z::Session::start_read_task() {
     ErrNo error;
     return start_read_task(error);
 }
-inline bool Session::start_read_task(ErrNo& error) {
+inline bool z::Session::start_read_task(ErrNo& error) {
     error = ::zp_start_read_task(loan(), nullptr);
     return error == 0;
 }
-inline bool Session::stop_read_task() {
+inline bool z::Session::stop_read_task() {
     ErrNo error;
     return stop_read_task(error);
 }
-inline bool Session::stop_read_task(ErrNo& error) {
+inline bool z::Session::stop_read_task(ErrNo& error) {
     error = ::zp_stop_read_task(loan());
     return error == 0;
 }
-inline bool Session::start_lease_task() {
+inline bool z::Session::start_lease_task() {
     ErrNo error;
     return start_lease_task(error);
 }
-inline bool Session::start_lease_task(ErrNo& error) {
+inline bool z::Session::start_lease_task(ErrNo& error) {
     error = ::zp_start_lease_task(loan(), nullptr);
     return error == 0;
 }
-inline bool Session::stop_lease_task() {
+inline bool z::Session::stop_lease_task() {
     ErrNo error;
     return stop_lease_task(error);
 }
-inline bool Session::stop_lease_task(ErrNo& error) {
+inline bool z::Session::stop_lease_task(ErrNo& error) {
     error = ::zp_stop_lease_task(loan());
     return error == 0;
 }
-inline bool Session::read() {
+inline bool z::Session::read() {
     ErrNo error;
     return read(error);
 }
-inline bool Session::read(ErrNo& error) {
+inline bool z::Session::read(ErrNo& error) {
     error = ::zp_read(loan(), nullptr);
     return error == 0;
 }
-inline bool Session::send_keep_alive() {
+inline bool z::Session::send_keep_alive() {
     ErrNo error;
     return send_keep_alive(error);
 }
-inline bool Session::send_keep_alive(ErrNo& error) {
+inline bool z::Session::send_keep_alive(ErrNo& error) {
     error = ::zp_send_keep_alive(loan(), nullptr);
     return error == 0;
 }
-inline bool Session::send_join() {
+inline bool z::Session::send_join() {
     ErrNo error;
     return send_join(error);
 }
-inline bool Session::send_join(ErrNo& error) {
+inline bool z::Session::send_join(ErrNo& error) {
     error = ::zp_send_join(loan(), nullptr);
     return error == 0;
 }
 #endif
+
+#ifdef __ZENOHCXX_ZENOHPICO
+// If the source is successfully resolved, i.e. it was keyexpression declared in the session and call to ``resolve``
+// function successfully returned keyexpr string representation, then the resolved keyexpr is returned. Otherwise, the
+// original source is returned.
+class _Resolved {
+   public:
+    _Resolved(const z::Session& s, const z::KeyExprView& source)
+        : str(std::move(source.resolve(s))),
+          keyexpr(str.check() ? z::KeyExprView(str.c_str(), KeyExprUnchecked()) : source) {}
+    operator const z::KeyExprView&() const { return keyexpr; }
+
+   private:
+    z::Str str;
+    const z::KeyExprView keyexpr;
+};
+#else
+class _Resolved {
+   public:
+    _Resolved(const z::Session&, const z::KeyExprView& source) : keyexpr(source) {}
+    operator const z::KeyExprView&() const { return keyexpr; }
+
+   private:
+    const z::KeyExprView& keyexpr;
+};
+#endif
+
+inline bool z::Session::keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
+    return z::keyexpr_equals(_Resolved(*this, a), _Resolved(*this, b), error);
+}
+
+inline bool z::Session::keyexpr_equals(const z::KeyExprView& a, const z::KeyExprView& b) {
+    ErrNo error;
+    return z::Session::keyexpr_equals(a, b, error);
+}
+
+inline bool z::Session::keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
+    return z::keyexpr_includes(_Resolved(*this, a), _Resolved(*this, b), error);
+}
+
+inline bool z::Session::keyexpr_includes(const z::KeyExprView& a, const z::KeyExprView& b) {
+    ErrNo error;
+    return z::Session::keyexpr_includes(a, b, error);
+}
+
+inline bool z::Session::keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b, ErrNo& error) {
+    return z::keyexpr_intersects(_Resolved(*this, a), _Resolved(*this, b), error);
+}
+
+inline bool z::Session::keyexpr_intersects(const z::KeyExprView& a, const z::KeyExprView& b) {
+    ErrNo error;
+    return z::Session::keyexpr_intersects(a, b, error);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,6 @@ function(add_test_instance file mode lib)
 	target_link_libraries(${target} PUBLIC ${lib})
 	set_property(TARGET ${target} PROPERTY LANGUAGE CXX)
 	set_property(TARGET ${target} PROPERTY CXX_STANDARD 17)
-	add_platform_libraries(${target})
 	add_test(NAME "test_${target}" COMMAND ${target})
 endfunction()
 

--- a/tests/universal/keyexpr.cxx
+++ b/tests/universal/keyexpr.cxx
@@ -135,45 +135,50 @@ void equals() {
     KeyExpr bar("BAR");
     KeyExprView barv("BAR");
 
+#ifdef ZENOHCXX_ZENOHC
     assert(foo.equals(foo));
+    assert(foo.equals(foov));
+    assert(foov.equals(foo));
+    assert(foov.equals(foov));
+    assert(keyexpr_equals("FOO", "FOO"));
+    assert(!keyexpr_equals("FOO", "BAR"));
+    assert(!keyexpr_equals("FOO", nul));
+    assert(!foo.equals(bar));
+    assert(!foo.equals(barv));
+    assert(!foov.equals(bar));
+    assert(!foov.equals(barv));
+    assert(!foo.equals(nul));
+    assert(!foov.equals(nul));
+#endif
     assert(foo.equals(foo, err));
     assert(err == 0);
-    assert(foo.equals(foov));
     assert(foo.equals(foov, err));
     assert(err == 0);
-    assert(foov.equals(foo));
     assert(foov.equals(foo, err));
     assert(err == 0);
-    assert(foov.equals(foov));
     assert(foov.equals(foov, err));
+    assert(err == 0);
 
-    assert(keyexpr_equals("FOO", "FOO"));
     assert(keyexpr_equals("FOO", "FOO", err));
     assert(err == 0);
 
-    assert(!foo.equals(bar));
     assert(!foo.equals(bar, err));
     assert(err == 0);
-    assert(!foo.equals(barv));
     assert(!foo.equals(barv, err));
     assert(err == 0);
-    assert(!foov.equals(bar));
     assert(!foov.equals(bar, err));
     assert(err == 0);
-    assert(!foov.equals(barv));
     assert(!foov.equals(barv, err));
+    assert(err == 0);
 
-    assert(!keyexpr_equals("FOO", "BAR"));
     assert(!keyexpr_equals("FOO", "BAR", err));
     assert(err == 0);
 
-    assert(!foo.equals(nul));
     assert(!foo.equals(nul, err));
     assert(err < 0);
-    assert(!foov.equals(nul));
     assert(!foov.equals(nul, err));
+    assert(err < 0);
 
-    assert(!keyexpr_equals("FOO", nul));
     assert(!keyexpr_equals("FOO", nul, err));
     assert(err < 0);
 }
@@ -184,40 +189,52 @@ void includes() {
 
     KeyExprView foostarv("FOO/*");
     KeyExprView foobarv("FOO/BAR");
-    assert(foostarv.includes(foobarv));
-    assert(foostarv.includes(foobarv, err));
-    assert(!foobarv.includes(foostarv));
-    assert(!foobarv.includes(foostarv, err));
-    assert(!foostarv.includes(nul));
-    assert(!foostarv.includes(nul, err));
 
+#ifdef ZENOHCXX_ZENOHC
+    assert(foostarv.includes(foobarv));
+    assert(!foobarv.includes(foostarv));
+    assert(!foostarv.includes(nul));
     assert(keyexpr_includes("FOO/*", "FOO/BAR"));
+#endif
+
+    assert(foostarv.includes(foobarv, err));
+    assert(err == 0);
+    assert(!foobarv.includes(foostarv, err));
+    assert(err == 0);
+    assert(!foostarv.includes(nul, err));
+    assert(err < 0);
     assert(keyexpr_includes("FOO/*", "FOO/BAR", err));
     assert(err == 0);
 
     KeyExpr foostar("FOO/*");
     KeyExpr foobar("FOO/BAR");
+
+#ifdef ZENOHCXX_ZENOHC
     assert(foostar.includes(foobar));
-    assert(foostar.includes(foobar, err));
     assert(!foobar.includes(foostar));
-    assert(!foobar.includes(foostar, err));
     assert(!foostar.includes(nul));
+    assert(!keyexpr_includes("FOO/BAR", "FOO/*"));
+    assert(!keyexpr_includes("FOO/*", nul));
+#endif
+
+    assert(foostar.includes(foobar, err));
+    assert(err == 0);
+    assert(!foobar.includes(foostar, err));
+    assert(err == 0);
     assert(!foostar.includes(nul, err));
     assert(err < 0);
-
-    assert(!keyexpr_includes("FOO/BAR", "FOO/*"));
     assert(!keyexpr_includes("FOO/BAR", "FOO/*", err));
     assert(err == 0);
-
-    assert(!keyexpr_includes("FOO/*", nul));
     assert(!keyexpr_includes("FOO/*", nul, err));
     assert(err < 0);
 
     KeyExpr foo("FOO");
+#ifdef ZENOHCXX_ZENOHC
     assert(!keyexpr_includes(foo, "FOO/BAR"));
+    assert(!keyexpr_includes("FOO/BAR", foo));
+#endif
     assert(!keyexpr_includes(foo, "FOO/BAR", err));
     assert(err == 0);
-    assert(!keyexpr_includes("FOO/BAR", foo));
     assert(!keyexpr_includes("FOO/BAR", foo, err));
     assert(err == 0);
 }
@@ -229,41 +246,58 @@ void intersects() {
     KeyExprView foostarv("FOO/*");
     KeyExprView foobarv("FOO/BAR");
     KeyExprView starbuzv("*/BUZ");
+
+#ifdef ZENOHCXX_ZENOHC
     assert(foostarv.intersects(foobarv));
     assert(!starbuzv.intersects(foobarv));
     assert(!foostarv.intersects(nul));
+    assert(keyexpr_intersects("FOO/*", "FOO/BAR"));
+    assert(!keyexpr_intersects("*/BUZ", "FOO/BAR"));
+    assert(!keyexpr_intersects("FOO/*", nul));
+#endif
+
     assert(foostarv.intersects(foobarv, err));
+    assert(err == 0);
     assert(!starbuzv.intersects(foobarv, err));
+    assert(err == 0);
     assert(!foostarv.intersects(nul, err));
     assert(err != 0);
 
-    assert(keyexpr_intersects("FOO/*", "FOO/BAR"));
     assert(keyexpr_intersects("FOO/*", "FOO/BAR", err));
     assert(err == 0);
 
-    assert(!keyexpr_intersects("*/BUZ", "FOO/BAR"));
     assert(!keyexpr_intersects("*/BUZ", "FOO/BAR", err));
     assert(err == 0);
 
-    assert(!keyexpr_intersects("FOO/*", nul));
     assert(!keyexpr_intersects("FOO/*", nul, err));
     assert(err < 0);
 
     KeyExpr foostar("FOO/*");
     KeyExpr foobar("FOO/BAR");
     KeyExpr starbuz("*/BUZ");
+
+#ifdef ZENOHCXX_ZENOHC
     assert(foostar.intersects(foobar));
     assert(!starbuz.intersects(foobar));
     assert(!foostar.intersects(nul));
+    assert(keyexpr_intersects("FOO/*", foobar));
+    assert(!keyexpr_intersects("*/BUZ", foobar));
+    assert(!keyexpr_intersects("FOO/*", nul));
+#endif
+
     assert(foostar.intersects(foobar, err));
     assert(err == 0);
     assert(!starbuz.intersects(foobar, err));
+    assert(err == 0);
     assert(!foostar.intersects(nul, err));
     assert(err != 0);
 
-    assert(keyexpr_intersects("FOO/*", foobar));
     assert(keyexpr_intersects("FOO/*", foobar, err));
     assert(err == 0);
+    assert(!keyexpr_intersects("*/BUZ", foobar, err));
+    assert(err == 0);
+    assert(!keyexpr_intersects("FOO/*", nul, err));
+    assert(err < 0);
 }
 
 #include <variant>


### PR DESCRIPTION
Fix fox issue https://github.com/eclipse-zenoh/zenoh-cpp/issues/20:

- keyexpr compare funciton without error check disallowed for zenohpico as they can provide false results
- keyexpr compare functions with automatic resolving of session declared keyexprs added to `Session` class