### PR TITLE
get_keyexpr method for publisher and subscriber

### DIFF
--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -66,11 +66,14 @@ int _main(int argc, char **argv) {
         }
     }
 
-    printf("Opening session...\n");
+    std::cout << "Opening session..." << std::endl;
     auto session = std::get<Session>(open(std::move(config)));
 
-    printf("Declaring Publisher on '%s'...\n", keyexpr);
+    std::cout << "Declaring Publisher on '" << keyexpr << "'..." << std::endl;
     auto pub = std::get<Publisher>(session.declare_publisher(keyexpr));
+#ifdef ZENOHCXX_ZENOHC
+    std::cout << "Publisher on '" << pub.get_keyexpr().as_string_view() << "' declared" << std::endl;
+#endif
 
     PublisherPutOptions options;
     options.set_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);

--- a/examples/universal/z_sub.cxx
+++ b/examples/universal/z_sub.cxx
@@ -26,74 +26,72 @@ using namespace zenoh;
 const char *kind_to_str(z_sample_kind_t kind);
 
 void data_handler(const Sample &sample) {
-    void data_handler(const Sample &sample) {
-        std::cout << ">> [Subscriber] Received " << kind_to_str(sample.get_kind()) << " ('"
-                  << sample.get_keyexpr().as_string_view() << "' : '" << sample.get_payload().as_string_view()
-                  << "')\n";
-    }
+    std::cout << ">> [Subscriber] Received " << kind_to_str(sample.get_kind()) << " ('"
+              << sample.get_keyexpr().as_string_view() << "' : '" << sample.get_payload().as_string_view() << "')\n";
+}
 
-    int _main(int argc, char **argv) {
-        const char *expr = "demo/example/**";
-        const char *locator = nullptr;
+int _main(int argc, char **argv) {
+    const char *expr = "demo/example/**";
+    const char *locator = nullptr;
 
-        if (argc > 1) expr = argv[1];
-        if (argc > 2) locator = argv[2];
+    if (argc > 1) expr = argv[1];
+    if (argc > 2) locator = argv[2];
 
-        Config config;
-        if (locator) {
+    Config config;
+    if (locator) {
 #ifdef ZENOHCXX_ZENOHC
-            auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-            if (!config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str()))
+        auto locator_json_str_list = std::string("[\"") + locator + "\"]";
+        if (!config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str()))
 #elif ZENOHCXX_ZENOHPICO
-            if (!config.insert(Z_CONFIG_PEER_KEY, locator))
+        if (!config.insert(Z_CONFIG_PEER_KEY, locator))
 #else
 #error "Unknown zenoh backend"
 #endif
-            {
-                std::cout << "Invalid locator: " << locator << std::endl;
-                std::cout << "Expected value in format: tcp/192.168.64.3:7447" << std::endl;
-                exit(-1);
-            }
+        {
+            std::cout << "Invalid locator: " << locator << std::endl;
+            std::cout << "Expected value in format: tcp/192.168.64.3:7447" << std::endl;
+            exit(-1);
         }
+    }
 
-        KeyExprView keyexpr(expr);
+    KeyExprView keyexpr(expr);
 
-        std::cout << "Opening session..." << std::endl;
-        auto session = expect<Session>(open(std::move(config)));
+    std::cout << "Opening session..." << std::endl;
+    auto session = expect<Session>(open(std::move(config)));
 
-        std::cout << "Declaring Subscriber on '" << keyexpr.as_string_view() << "'..." << std::endl;
-        auto subscriber = expect<Subscriber>(session.declare_subscriber(keyexpr, data_handler));
+    std::cout << "Declaring Subscriber on '" << keyexpr.as_string_view() << "'..." << std::endl;
+    auto subscriber = expect<Subscriber>(session.declare_subscriber(keyexpr, data_handler));
 #ifdef ZENOHCXX_ZENOHC
-        std::cout << "Subscriber on '" << subscriber.get_keyexpr().as_string_view() << "' declared" << std::endl;
+    std::cout << "Subscriber on '" << subscriber.get_keyexpr().as_string_view() << "' declared" << std::endl;
 #endif
 
-        printf("Enter 'q' to quit...\n");
-        char c = 0;
-        while (c != 'q') {
-            c = getchar();
-            if (c == -1) {
-                sleep(1);
-            }
-        }
-
-        return 0;
-    }
-
-    const char *kind_to_str(z_sample_kind_t kind) {
-        switch (kind) {
-            case Z_SAMPLE_KIND_PUT:
-                return "PUT";
-            case Z_SAMPLE_KIND_DELETE:
-                return "DELETE";
-            default:
-                return "UNKNOWN";
+    printf("Enter 'q' to quit...\n");
+    char c = 0;
+    while (c != 'q') {
+        c = getchar();
+        if (c == -1) {
+            sleep(1);
         }
     }
 
-    int main(int argc, char **argv) {
-        try {
-            _main(argc, argv);
-        } catch (ErrorMessage e) {
-            std::cout << "Received an error :" << e.as_string_view() << "\n";
-        }
+    return 0;
+}
+
+const char *kind_to_str(z_sample_kind_t kind) {
+    switch (kind) {
+        case Z_SAMPLE_KIND_PUT:
+            return "PUT";
+        case Z_SAMPLE_KIND_DELETE:
+            return "DELETE";
+        default:
+            return "UNKNOWN";
     }
+}
+
+int main(int argc, char **argv) {
+    try {
+        _main(argc, argv);
+    } catch (ErrorMessage e) {
+        std::cout << "Received an error :" << e.as_string_view() << "\n";
+    }
+}

--- a/examples/universal/z_sub.cxx
+++ b/examples/universal/z_sub.cxx
@@ -25,10 +25,9 @@ using namespace zenoh;
 
 const char *kind_to_str(z_sample_kind_t kind);
 
-void data_handler(const Sample& sample) {
+void data_handler(const Sample &sample) {
     std::cout << ">> [Subscriber] Received " << kind_to_str(sample.get_kind()) << " ('"
-                << sample.get_keyexpr().as_string_view() << "' : '" << sample.get_payload().as_string_view()
-                << "')\n";
+              << sample.get_keyexpr().as_string_view() << "' : '" << sample.get_payload().as_string_view() << "')\n";
 }
 
 int _main(int argc, char **argv) {
@@ -57,11 +56,14 @@ int _main(int argc, char **argv) {
 
     KeyExprView keyexpr(expr);
 
-    printf("Opening session...\n");
+    std::cout << "Opening session..." << std::endl;
     auto session = std::get<Session>(open(std::move(config)));
 
-    printf("Declaring Subscriber on '%s'...\n", expr);
+    std::cout << "Declaring Subscriber on '" << keyexpr.as_string_view() << "'..." << std::endl;
     auto subscriber = std::get<Subscriber>(session.declare_subscriber(keyexpr, data_handler));
+#ifdef ZENOHCXX_ZENOHC
+    std::cout << "Subscriber on '" << subscriber.get_keyexpr().as_string_view() << "' declared" << std::endl;
+#endif
 
     printf("Enter 'q' to quit...\n");
     char c = 0;

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -1544,6 +1544,12 @@ class Reply : public Owned<::z_owned_reply_t> {
 class Subscriber : public Owned<::z_owned_subscriber_t> {
    public:
     using Owned::Owned;
+
+#ifdef __ZENOHCXX_ZENOHC
+    /// @brief Get the key expression of the subscriber
+    /// @return ``zenoh::KeyExpr`` value
+    z::KeyExpr get_keyexpr() const;
+#endif
 };
 
 /// An owned zenoh pull subscriber. Destroying the subscriber cancels the subscription.
@@ -1623,6 +1629,12 @@ class Publisher : public Owned<::z_owned_publisher_t> {
     /// @brief Send a delete request
     /// @return true if the request was sent, false otherwise
     bool delete_resource();
+
+#ifdef __ZENOHCXX_ZENOHC
+    /// @brief Get the key expression of the publisher
+    /// @return ``zenoh::KeyExpr`` value
+    z::KeyExpr get_keyexpr() const;
+#endif
 
 #ifdef __ZENOHCXX_ZENOHC
     /// @brief Publish the payload got from ``ShmBuf`` or from ``Sample``

--- a/include/zenohcxx/impl.hxx
+++ b/include/zenohcxx/impl.hxx
@@ -258,6 +258,14 @@ inline bool z::Publisher::put_owned_impl(z::Payload&& payload, const z::Publishe
 
 #endif
 
+#ifdef __ZENOHCXX_ZENOHC
+z::KeyExpr z::Publisher::get_keyexpr() const { return ::z_publisher_keyexpr(loan()); }
+#endif
+
+#ifdef __ZENOHCXX_ZENOHC
+z::KeyExpr z::Subscriber::get_keyexpr() const { return ::z_subscriber_keyexpr(loan()); }
+#endif
+
 inline bool scout(z::ScoutingConfig&& config, ClosureHello&& callback, ErrNo& error) {
     auto c = config.take();
     auto cb = callback.take();


### PR DESCRIPTION
Added methods wrapping zenoh-c functions `z_publisher_keyexpr` and `z_subscriber_keyexpr`.
Note that these functions exists in zenoh-c only. Should we implement them in zehoh-pico too?