### PR TITLE
replaced `std::get` to own utility function `expect` which throws error

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ void on_query(const Query& query) { ... };
 ...
 auto queryable = std::get<Queryable>(session.declare_queryable("foo/bar", on_query);
 ```
+Instead of `std::get` it makes sense to use `zenoh::expect` here. It is a helper template which takes `std::variant<T,ErrorMessage>` and
+either returns `T` or throws `ErrorMessage`:
+```C++
+auto queryable = expect(session.declare_queryable("foo/bar", on_query));
+```
 
 The `ClosureMoveParam` types accepts types, invocable with `Foo`, `Foo&` or `Foo&&`. Callback may take ownership of the reference parameter passed
 or do nothing and leave to caller to drop it.

--- a/docs/enums.rst
+++ b/docs/enums.rst
@@ -19,6 +19,8 @@ Enum types are C++ - style typedefs for corrresponding enums of `zenoh-c`_ / `ze
 
 .. doxygentypedef:: ErrorMessage
 
+.. doxygenfunction:: expect
+
 .. doxygentypedef:: ErrNo
 
 .. doxygentypedef:: SampleKind

--- a/docs/pubsub.rst
+++ b/docs/pubsub.rst
@@ -27,7 +27,7 @@ Publisher example:
 
    int main(int argc, char **argv) {
       Config config;
-      auto session = std::get<Session>(open(std::move(config)));
+      auto session = expect<Session>(open(std::move(config)));
       // Publish without creating a Publisher object
       session.put("demo/example/simple", "Simple!");
 
@@ -46,8 +46,8 @@ Subscriber example:
 
    int main(int argc, char **argv) {
       Config config;
-      auto session = std::get<Session>(open(std::move(config)));
-      auto subscriber = std::get<Subscriber>(
+      auto session = expect<Session>(open(std::move(config)));
+      auto subscriber = expect<Subscriber>(
          session.declare_subscriber("demo/example/simple", [](const Sample& sample) {
             std::cout << "Received: " << sample.get_payload().as_string_view() << std::endl;
          })

--- a/docs/queryable.rst
+++ b/docs/queryable.rst
@@ -29,8 +29,8 @@ Queryable example:
    int main(int argc, char **argv) {
       auto queryable_keyexpr = "demo/example/simple";
       Config config;
-      auto session = std::get<Session>(open(std::move(config)));
-      auto queryable = std::get<Queryable>(
+      auto session = expect<Session>(open(std::move(config)));
+      auto queryable = expect<Queryable>(
          session.declare_queryable(queryable_keyexpr, [](const Query& query) {
             std::cout << "Received Query '" 
                       << query.get_keyexpr().as_string_view() 
@@ -52,7 +52,7 @@ Also notice that the callback is processed asynchronously, so the client must no
 
    int main(int argc, char **argv) {
       Config config;
-      auto session = std::get<Session>(open(std::move(config)));
+      auto session = expect<Session>(open(std::move(config)));
 
       auto on_reply = [](Reply&& reply) {
          auto result = reply.get();

--- a/docs/session_ex.rst
+++ b/docs/session_ex.rst
@@ -27,10 +27,10 @@ consuming the configuration object :cpp:class:`zenoh::Config`.
       try {
          Config config;
          // take Session from std::variant
-         auto session = std::get<Session>(open(std::move(config)));
+         auto session = expect<Session>(open(std::move(config)));
          session.put("demo/example/simple", "Simple!");
       } catch (ErrorMessage e) {
-         // Exception comes from ``std::get``, the zenoh-cpp itself does not throw any exception
+         // Exception comes from ``expect``, the zenoh-cpp itself does not throw any exception
          std::cout << "Received an error :" << e.as_string_view() << "\n";
       }
    }

--- a/examples/simple/universal/z_simple.cxx
+++ b/examples/simple/universal/z_simple.cxx
@@ -32,11 +32,11 @@ class CustomerClass {
 
     CustomerClass(const KeyExprView& keyexpr) : session(nullptr), pub(nullptr) {
         Config config;
-        Session s = std::get<Session>(open(std::move(config)));
+        Session s = expect(open(std::move(config)));
         session = std::move(s);
         // Publisher holds a reference to the Session, so after creating the publisher the session should
         // not be moved anymore (as well as the whole CustomerClass)
-        Publisher p = std::get<Publisher>(session.declare_publisher(keyexpr));
+        Publisher p = expect(session.declare_publisher(keyexpr));
         pub = std::move(p);
     }
 

--- a/examples/simple/zenohc/zc_simple.cxx
+++ b/examples/simple/zenohc/zc_simple.cxx
@@ -21,6 +21,6 @@ using namespace zenohc;
 
 int main(int argc, char **argv) {
     Config config;
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
     session.put("demo/example/simple", "Simple!");
 }

--- a/examples/simple/zenohpico/zp_simple.cxx
+++ b/examples/simple/zenohpico/zp_simple.cxx
@@ -21,6 +21,6 @@ using namespace zenohpico;
 
 int main(int argc, char **argv) {
     Config config;
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
     session.put("demo/example/simple", "Simple!");
 }

--- a/examples/universal/z_delete.cxx
+++ b/examples/universal/z_delete.cxx
@@ -50,7 +50,7 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     printf("Deleting resources matching '%s'...\n", keyexpr);
     ErrNo error;

--- a/examples/universal/z_get.cxx
+++ b/examples/universal/z_get.cxx
@@ -54,7 +54,7 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     std::cout << "Sending Query '" << expr << "'...\n";
     GetOptions opts;

--- a/examples/universal/z_info.cxx
+++ b/examples/universal/z_info.cxx
@@ -44,7 +44,7 @@ int _main(int argc, char** argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     auto self_id = session.info_zid();
     printf("own id: ");

--- a/examples/universal/z_ping.cxx
+++ b/examples/universal/z_ping.cxx
@@ -49,17 +49,17 @@ int _main(int argc, char** argv) {
     Config config;
 #ifdef ZENOHCXX_ZENOHC
     if (args.config_path) {
-        config = std::get<Config>(config_from_file(args.config_path));
+        config = expect<Config>(config_from_file(args.config_path));
     }
 #endif
     std::cout << "Opening session...\n";
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
-    auto sub = std::get<Subscriber>(
+    auto sub = expect<Subscriber>(
         session.declare_subscriber("test/pong", std::move([&condvar](const Sample&) mutable {
                                         condvar.notify_one();
                                    })));
-    auto pub = std::get<Publisher>(session.declare_publisher("test/ping"));
+    auto pub = expect<Publisher>(session.declare_publisher("test/ping"));
     std::vector<char> data(args.size);
     std::unique_lock lock(mutex);
     if (args.warmup_ms) {

--- a/examples/universal/z_pong.cxx
+++ b/examples/universal/z_pong.cxx
@@ -22,10 +22,10 @@ int _main(int argc, char **argv) {
     Config config;
 
     std::cout << "Opening session...\n";
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
-    auto pub = std::get<Publisher>(session.declare_publisher("test/pong"));
-    auto sub = std::get<Subscriber>(
+    auto pub = expect<Publisher>(session.declare_publisher("test/pong"));
+    auto sub = expect<Subscriber>(
         session.declare_subscriber("test/ping", std::move([pub = std::move(pub)](const Sample& sample) mutable {
                                         pub.put(sample.get_payload());
                                    })));

--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -67,10 +67,10 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     printf("Declaring Publisher on '%s'...\n", keyexpr);
-    auto pub = std::get<Publisher>(session.declare_publisher(keyexpr));
+    auto pub = expect<Publisher>(session.declare_publisher(keyexpr));
 
     PublisherPutOptions options;
     options.set_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);

--- a/examples/universal/z_pub_delete.cxx
+++ b/examples/universal/z_pub_delete.cxx
@@ -50,10 +50,10 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     printf("Declaring Publisher on '%s'...\n", keyexpr);
-    auto pub = std::get<Publisher>(session.declare_publisher(keyexpr));
+    auto pub = expect<Publisher>(session.declare_publisher(keyexpr));
 
     printf("Deleting...");
     pub.delete_resource();

--- a/examples/universal/z_pub_thr.cxx
+++ b/examples/universal/z_pub_thr.cxx
@@ -50,13 +50,13 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     PublisherOptions options;
     options.set_congestion_control(Z_CONGESTION_CONTROL_BLOCK);
 
     printf("Declaring Publisher on '%s'...\n", keyexpr);
-    auto pub = std::get<Publisher>(session.declare_publisher(keyexpr, options));
+    auto pub = expect<Publisher>(session.declare_publisher(keyexpr, options));
 
     while (1) pub.put(payload);
 }

--- a/examples/universal/z_pull.cxx
+++ b/examples/universal/z_pull.cxx
@@ -58,10 +58,10 @@ int _main(int argc, char **argv) {
     KeyExprView keyexpr(expr);
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     printf("Declaring Subscriber on '%s'...\n", expr);
-    auto subscriber = std::get<PullSubscriber>(session.declare_pull_subscriber(keyexpr, data_handler));
+    auto subscriber = expect<PullSubscriber>(session.declare_pull_subscriber(keyexpr, data_handler));
 
     printf("Press <enter> to pull data...\n");
     char c = 0;

--- a/examples/universal/z_put.cxx
+++ b/examples/universal/z_put.cxx
@@ -54,7 +54,7 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
     PutOptions options;

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -58,7 +58,7 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     KeyExprView keyexpr(expr);
     if (!keyexpr.check()) {
@@ -81,7 +81,7 @@ int _main(int argc, char **argv) {
 
     auto on_drop_queryable = []() { std::cout << "Destroying queryable\n"; };
 
-    auto queryable = std::get<Queryable>(session.declare_queryable(keyexpr, {on_query, on_drop_queryable}));
+    auto queryable = expect<Queryable>(session.declare_queryable(keyexpr, {on_query, on_drop_queryable}));
 
     printf("Enter 'q' to quit...\n");
     char c = 0;

--- a/examples/universal/z_sub.cxx
+++ b/examples/universal/z_sub.cxx
@@ -25,10 +25,9 @@ using namespace zenoh;
 
 const char *kind_to_str(z_sample_kind_t kind);
 
-void data_handler(const Sample& sample) {
+void data_handler(const Sample &sample) {
     std::cout << ">> [Subscriber] Received " << kind_to_str(sample.get_kind()) << " ('"
-                << sample.get_keyexpr().as_string_view() << "' : '" << sample.get_payload().as_string_view()
-                << "')\n";
+              << sample.get_keyexpr().as_string_view() << "' : '" << sample.get_payload().as_string_view() << "')\n";
 }
 
 int _main(int argc, char **argv) {
@@ -58,10 +57,10 @@ int _main(int argc, char **argv) {
     KeyExprView keyexpr(expr);
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     printf("Declaring Subscriber on '%s'...\n", expr);
-    auto subscriber = std::get<Subscriber>(session.declare_subscriber(keyexpr, data_handler));
+    auto subscriber = expect<Subscriber>(session.declare_subscriber(keyexpr, data_handler));
 
     printf("Enter 'q' to quit...\n");
     char c = 0;

--- a/examples/universal/z_sub_thr.cxx
+++ b/examples/universal/z_sub_thr.cxx
@@ -76,12 +76,12 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     KeyExpr keyexpr = session.declare_keyexpr("test/thr");
 
     Stats stats;
-    auto subscriber = std::get<Subscriber>(session.declare_subscriber(keyexpr, {stats, stats}));
+    auto subscriber = expect<Subscriber>(session.declare_subscriber(keyexpr, {stats, stats}));
     char c = 0;
     while (c != 'q') {
         c = fgetc(stdin);

--- a/examples/zenohc/z_get_channel.cxx
+++ b/examples/zenohc/z_get_channel.cxx
@@ -42,7 +42,7 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     std::cout << "Sending Query '" << expr << "'...\n";
     GetOptions opts;
@@ -53,7 +53,7 @@ int _main(int argc, char **argv) {
 
     Reply reply(nullptr);
     for (recv(reply); reply.check(); recv(reply)) {
-        auto sample = std::get<Sample>(reply.get());
+        auto sample = expect<Sample>(reply.get());
         std::cout << "Received ('" << sample.get_keyexpr().as_string_view() << "' : '"
                   << sample.get_payload().as_string_view() << "')\n";
     }

--- a/examples/zenohc/z_get_channel_non_blocking.cxx
+++ b/examples/zenohc/z_get_channel_non_blocking.cxx
@@ -48,7 +48,7 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
 
     std::cout << "Sending Query '" << expr << "'...\n";
     GetOptions opts;
@@ -64,7 +64,7 @@ int _main(int argc, char **argv) {
             Sleep(1);
             continue;
         }
-        auto sample = std::get<Sample>(reply.get());
+        auto sample = expect<Sample>(reply.get());
         std::cout << "\nReceived ('" << sample.get_keyexpr().as_string_view() << "' : '"
                   << sample.get_payload().as_string_view() << "')";
     }

--- a/examples/zenohc/z_pub_shm.cxx
+++ b/examples/zenohc/z_pub_shm.cxx
@@ -68,19 +68,19 @@ int _main(int argc, char **argv) {
     }
 
     printf("Opening session...\n");
-    auto session = std::get<Session>(open(std::move(config)));
+    auto session = expect<Session>(open(std::move(config)));
     std::ostringstream oss;
     oss << session.info_zid();
 
-    auto manager = std::get<ShmManager>(shm_manager_new(session, oss.str().c_str(), N * 256));
+    auto manager = expect<ShmManager>(shm_manager_new(session, oss.str().c_str(), N * 256));
 
     printf("Declaring Publisher on '%s'...\n", keyexpr);
-    auto pub = std::get<Publisher>(session.declare_publisher(keyexpr));
+    auto pub = expect<Publisher>(session.declare_publisher(keyexpr));
 
     PublisherPutOptions options;
     options.set_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);
     for (int idx = 0; idx < N; ++idx) {
-        auto shmbuf = std::get<z::Shmbuf>(manager.alloc(256));
+        auto shmbuf = expect<z::Shmbuf>(manager.alloc(256));
         auto buf = shmbuf.char_ptr();
         snprintf(buf, 255, "[%4d] %s", idx, value);
         shmbuf.set_length(strlen(buf));

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -36,9 +36,23 @@ using namespace zenohcxx;
 class Session;
 class Value;
 
-/// Text error message returned in ``std::variant<T, ErrorMessage>`` retrun types.
-/// The message is a sting represented as ``zenoh::Value`` object
+/// Text error message returned in ``std::variant<T, ErrorMessage>`` return types.
+/// The message is a sting represented as ``zenoh::Value`` object. See also ``zenoh::expect`` function
+/// which eases access to the return value in this variant type.
 typedef z::Value ErrorMessage;
+
+/// Uility function which either returns the value or throws an exception with the ``zenoh::ErrorMessage`` value
+/// @param v the ``std::variant<T, zenoh:::ErrorMessage>`` value
+/// @return the value of type ``T`` if ``std::variant<T, zenoh::ErrorMessage>`` value contains it
+/// @throws  ``zenoh::ErrorMessage`` if ``std::variant<T, zenoh::ErrorMessage>`` value contains it
+template <typename T>
+inline T expect(std::variant<T, z::Value>&& v) {
+    if (std::holds_alternative<z::Value>(std::move(v))) {
+        throw std::get<z::Value>(std::move(v));
+    } else {
+        return std::get<T>(std::move(v));
+    }
+}
 
 /// Numeric error code value. This is a value < -1 returned by zenoh-c functions
 typedef int8_t ErrNo;
@@ -56,10 +70,11 @@ typedef ::z_sample_kind_t SampleKind;
 ///
 ///   Values:
 ///     - **Z_ENCODING_PREFIX_EMPTY**: Encoding not defined.
-///     - **Z_ENCODING_PREFIX_APP_OCTET_STREAM**: ``application/octet-stream``. Default value for all other cases. An
-///     unknown file type should use this type.
+///     - **Z_ENCODING_PREFIX_APP_OCTET_STREAM**: ``application/octet-stream``. Default value for all other cases.
+///     An unknown file type should use this type.
 ///     - **Z_ENCODING_PREFIX_APP_CUSTOM**: Custom application type. Non IANA standard.
-///     - **Z_ENCODING_PREFIX_TEXT_PLAIN**: ``text/plain``. Default value for textual files. A textual file should be
+///     - **Z_ENCODING_PREFIX_TEXT_PLAIN**: ``text/plain``. Default value for textual files. A textual file should
+///     be
 ///         human-readable and must not contain binary data.
 ///     - **Z_ENCODING_PREFIX_APP_PROPERTIES**: Application properties
 ///         type. Non IANA standard.
@@ -69,8 +84,8 @@ typedef ::z_sample_kind_t SampleKind;
 ///     - **Z_ENCODING_PREFIX_APP_FLOAT**: Application float type. Non IANA standard.
 ///     - **Z_ENCODING_PREFIX_APP_XML**: ``application/xml``. XML.
 ///     - **Z_ENCODING_PREFIX_APP_XHTML_XML**: ``application/xhtml+xml``. XHTML.
-///     - **Z_ENCODING_PREFIX_APP_X_WWW_FORM_URLENCODED**: ``application/x-www-form-urlencoded``. The keys and values
-///     are encoded in key-value tuples separated by '&', with a '=' between the key and the value.
+///     - **Z_ENCODING_PREFIX_APP_X_WWW_FORM_URLENCODED**: ``application/x-www-form-urlencoded``. The keys and
+///     values are encoded in key-value tuples separated by '&', with a '=' between the key and the value.
 ///     - **Z_ENCODING_PREFIX_TEXT_JSON**: Text JSON. Non IANA standard.
 ///     - **Z_ENCODING_PREFIX_TEXT_HTML**: ``text/html``.  HyperText Markup Language (HTML).
 ///     - **Z_ENCODING_PREFIX_TEXT_XML**: ``text/xml``. `Application/xml` is recommended as of RFC
@@ -86,8 +101,10 @@ typedef ::z_encoding_prefix_t EncodingPrefix;
 ///   Consolidation mode values.
 ///
 ///   Values:
-///       - **Z_CONSOLIDATION_MODE_AUTO**: Let Zenoh decide the best consolidation mode depending on the query selector.
-///       - **Z_CONSOLIDATION_MODE_NONE**: No consolidation is applied. Replies may come in any order and any number.
+///       - **Z_CONSOLIDATION_MODE_AUTO**: Let Zenoh decide the best consolidation mode depending on the query
+///       selector.
+///       - **Z_CONSOLIDATION_MODE_NONE**: No consolidation is applied. Replies may come in any order and any
+///       number.
 ///       - **Z_CONSOLIDATION_MODE_MONOTONIC**: It guarantees that any reply for a given key expression will be
 ///       monotonic in time
 ///           w.r.t. the previous received replies for the same key expression. I.e., for the same key expression
@@ -109,8 +126,8 @@ typedef ::z_reliability_t Reliability;
 ///   Values:
 ///    - **Z_CONGESTION_CONTROL_BLOCK**: Defines congestion control as "block". Messages are not dropped in case of
 ///       congestion control
-///    - **Z_CONGESTION_CONTROL_DROP**: Defines congestion control as "drop". Messages are dropped in case of congestion
-///    control
+///    - **Z_CONGESTION_CONTROL_DROP**: Defines congestion control as "drop". Messages are dropped in case of
+///    congestion control
 ///
 typedef ::z_congestion_control_t CongestionControl;
 

--- a/tests/zenohc/session.cxx
+++ b/tests/zenohc/session.cxx
@@ -21,7 +21,7 @@ using namespace zenohc;
 
 void test_session_rcinc() {
     Config config;
-    auto s1 = std::get<Session>(open(std::move(config)));
+    auto s1 = expect<Session>(open(std::move(config)));
     auto s2 = s1.rcinc();
     assert(s1.check());
     assert(s2.check());


### PR DESCRIPTION
It was incorrect to access, for example, `Session` from `std::variant<Session, ErrorMessage>` with `std::get`. `std::get` throws `std::bad_variant_access` and the `ErrorMessage` itself is lost.
Added template function `zenoh::expect` which returns value from variant or throws the `ErrorMessage`
