### PR TITLE
cmake min ver reduced to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 project(
 	zenohcxx
 	VERSION 0.10.0.0

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     # Settings when 'examples' is the root projet
-    cmake_minimum_required(VERSION 3.20)
+    cmake_minimum_required(VERSION 3.16)
     project(zenohcxx_examples LANGUAGES C CXX)
     include(../cmake/helpers.cmake)
     set_default_build_type(Release)

--- a/examples/simple/universal/CMakeLists.txt
+++ b/examples/simple/universal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 project(zenohcxx_examples LANGUAGES C CXX)
 
 if(CMAKE_BUILD_TYPE STREQUAL "")

--- a/examples/simple/zenohc/CMakeLists.txt
+++ b/examples/simple/zenohc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 project(zenohcxx_examples LANGUAGES C CXX)
 
 if(CMAKE_BUILD_TYPE STREQUAL "")

--- a/examples/simple/zenohpico/CMakeLists.txt
+++ b/examples/simple/zenohpico/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 project(zenohcxx_examples LANGUAGES C CXX)
 
 if(CMAKE_BUILD_TYPE STREQUAL "")

--- a/install/CMakeLists.txt
+++ b/install/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     # Settings when 'examples' is the root projet
-    cmake_minimum_required(VERSION 3.20)
+    cmake_minimum_required(VERSION 3.16)
     project(
         zenohcxx
         VERSION 0.10.0.0


### PR DESCRIPTION
Minimum required CMake version reduced to 3.16 to not require users to update CMake on Ubuntu 20.04