### PR TITLE
keyexpr test fix

### DIFF
--- a/tests/universal/keyexpr.cxx
+++ b/tests/universal/keyexpr.cxx
@@ -381,6 +381,13 @@ void includes_declared(Session& s) {
     assert(foobarv.check());
     assert(starbuzv.check());
 
+    assert(keyexpr_includes("FOO/*", "FOO/BAR", err));
+    assert(err == 0);
+    assert(!keyexpr_includes("*/BUZ", "FOO/BAR", err));
+    assert(err == 0);
+    assert(!keyexpr_includes("FOO/*", nul, err));
+    assert(err < 0);
+
 #ifdef ZENOHCXX_ZENOHC
     // zenoh-c is able to check declared keyexprs
     assert(foostar.includes(foobar, err));
@@ -389,12 +396,6 @@ void includes_declared(Session& s) {
     assert(err == 0);
     assert(!foostar.includes(nul, err));
     assert(err < 0);
-    assert(keyexpr_includes("FOO/*", "FOO/BAR", err));
-    assert(err == 0);
-    assert(!keyexpr_includes("*/BUZ", "FOO/BAR", err));
-    assert(err == 0);
-    assert(!keyexpr_includes("FOO/*", nul, err));
-    assert(err < 0);
 #else
     // zenoh-pico returns error when checking declared keyexprs: the string value is avaliable in session only
     assert(!foostar.includes(foobar, err));
@@ -402,12 +403,6 @@ void includes_declared(Session& s) {
     assert(!starbuz.includes(foobar, err));
     assert(err < 0);
     assert(!foostar.includes(nul, err));
-    assert(err < 0);
-    assert(!keyexpr_includes("FOO/*", "FOO/BAR", err));
-    assert(err < 0);
-    assert(!keyexpr_includes("*/BUZ", "FOO/BAR", err));
-    assert(err < 0);
-    assert(!keyexpr_includes("FOO/*", nul, err));
     assert(err < 0);
 #endif
 


### PR DESCRIPTION
Fix for https://github.com/eclipse-zenoh/zenoh-cpp/issues/83
- moved out tests common for zenoh-c and zenoh-pico
[TODO]
- make test fail if no connection to zenoh router (now it's not a failure, so zenoh-pico tests just skipped)
- add starting zenoh router before staring tests in CI
- fix issue 
```
keyexpr_zenohpico: /home/milyin/ZS2/zenoh-cpp/include/zenohcxx/api.hxx:504: zenohpico::KeyExprView::KeyExprView(const char*, zenohpico::KeyExprUnchecked): Assertion `keyexpr_is_canon(name)' failed.
```
