### PR TITLE
Attachment support implementation

### DIFF
--- a/examples/universal/z_get_attachment.cxx
+++ b/examples/universal/z_get_attachment.cxx
@@ -1,0 +1,116 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <condition_variable>
+#include <iostream>
+#include <map>
+#include <mutex>
+
+#include "../getargs.h"
+#include "zenoh.hxx"
+using namespace zenoh;
+
+int _main(int argc, char **argv) {
+    const char *expr = "demo/example/**";
+    const char *value = nullptr;
+    const char *configfile = nullptr;
+    getargs(argc, argv, {}, {{"key expression", &expr}, {"value", &value}}
+#ifdef ZENOHCXX_ZENOHC
+            ,
+            {{"-c", {"config file", &configfile}}}
+#endif
+    );
+
+    Config config;
+#ifdef ZENOHCXX_ZENOHC
+    if (configfile) {
+        config = expect(config_from_file(configfile));
+    }
+#endif
+
+    KeyExprView keyexpr(expr);
+    if (!keyexpr.check()) {
+        printf("%s is not a valid key expression", expr);
+        exit(-1);
+    }
+
+    printf("Opening session...\n");
+    auto session = expect<Session>(open(std::move(config)));
+
+    std::cout << "Sending Query '" << expr << "'...\n";
+    GetOptions opts;
+    opts.set_target(Z_QUERY_TARGET_ALL);
+    opts.set_value(value);
+#ifdef ZENOHCXX_ZENOHC
+    // allocate attachment map
+    std::map<std::string, std::string> amap;
+    // set it as an attachment
+    opts.set_attachment(amap);
+    // add some value
+    amap.insert(std::pair("source", "C++"));
+#endif
+
+    std::mutex m;
+    std::condition_variable done_signal;
+    bool done = false;
+
+    auto on_reply = [](Reply &&reply) {
+        auto result = reply.get();
+
+        if (auto sample = std::get_if<Sample>(&result)) {
+            std::cout << "Received ('" << sample->get_keyexpr().as_string_view() << "' : '"
+                      << sample->get_payload().as_string_view() << "')\n";
+#ifdef ZENOHCXX_ZENOHC
+            if (sample->get_attachment().check()) {
+                // reads full attachment
+                sample->get_attachment().iterate([](const BytesView &key, const BytesView &value) -> bool {
+                    std::cout << "   attachment: " << key.as_string_view() << ": '" << value.as_string_view() << "'\n";
+                    return true;
+                });
+
+                // reads particular attachment item
+                auto index = sample->get_attachment().get("source");
+                if (index != "") {
+                    std::cout << "   event source: " << index.as_string_view() << std::endl;
+                }
+            }
+#endif
+        } else if (auto error = std::get_if<ErrorMessage>(&result)) {
+            std::cout << "Received an error :" << error->as_string_view() << "\n";
+        }
+    };
+
+    auto on_done = [&m, &done, &done_signal]() {
+        std::lock_guard lock(m);
+        done = true;
+        done_signal.notify_all();
+    };
+
+    session.get(keyexpr, "", {on_reply, on_done}, opts);
+
+    std::unique_lock lock(m);
+    done_signal.wait(lock, [&done] { return done; });
+
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    try {
+        _main(argc, argv);
+    } catch (ErrorMessage e) {
+        std::cout << "Received an error :" << e.as_string_view() << "\n";
+    }
+}

--- a/examples/universal/z_pub_attachment.cxx
+++ b/examples/universal/z_pub_attachment.cxx
@@ -1,0 +1,103 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#include <stdio.h>
+#include <string.h>
+
+#include <iostream>
+#include <limits>
+#include <sstream>
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#undef min
+#undef max
+#define sleep(x) Sleep(x * 1000)
+#else
+#include <unistd.h>
+#endif
+
+#include "../getargs.h"
+#include "zenoh.hxx"
+using namespace zenoh;
+
+#ifdef ZENOHCXX_ZENOHC
+const char *default_value = "Pub from C++ zenoh-c!";
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-c-pub";
+#elif ZENOHCXX_ZENOHPICO
+const char *default_value = "Pub from C++ zenoh-pico!";
+const char *default_keyexpr = "demo/example/zenoh-cpp-zenoh-pico-pub";
+#else
+#error "Unknown zenoh backend"
+#endif
+
+int _main(int argc, char **argv) {
+    const char *keyexpr = default_keyexpr;
+    const char *value = default_value;
+    const char *configfile = nullptr;
+
+    getargs(argc, argv, {}, {{"key expression", &keyexpr}, {"value", &value}}
+#ifdef ZENOHCXX_ZENOHC
+            ,
+            {{"-c", {"config file", &configfile}}}
+#endif
+    );
+
+    Config config;
+#ifdef ZENOHCXX_ZENOHC
+    if (configfile) {
+        config = expect(config_from_file(configfile));
+    }
+#endif
+
+    std::cout << "Opening session..." << std::endl;
+    auto session = expect<Session>(open(std::move(config)));
+
+    std::cout << "Declaring Publisher on '" << keyexpr << "'..." << std::endl;
+    auto pub = expect<Publisher>(session.declare_publisher(keyexpr));
+#ifdef ZENOHCXX_ZENOHC
+    std::cout << "Publisher on '" << pub.get_keyexpr().as_string_view() << "' declared" << std::endl;
+#endif
+
+    PublisherPutOptions options;
+    options.set_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);
+#ifdef ZENOHCXX_ZENOHC
+    // allocate attachment map
+    std::map<std::string, std::string> amap;
+    // set it as an attachment
+    options.set_attachment(amap);
+    // add some value
+    amap.insert(std::pair("source", "C++"));
+#endif
+    for (int idx = 0; std::numeric_limits<int>::max(); ++idx) {
+        sleep(1);
+        std::ostringstream ss;
+        ss << "[" << idx << "] " << value;
+        auto s = ss.str();  // in C++20 use .view() instead
+        std::cout << "Putting Data ('" << keyexpr << "': '" << s << "')...\n";
+#ifdef ZENOHCXX_ZENOHC
+        // add some other attachment value
+        amap["index"] = std::to_string(idx);
+#endif
+        pub.put(s, options);
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    try {
+        _main(argc, argv);
+    } catch (ErrorMessage e) {
+        std::cout << "Received an error :" << e.as_string_view() << "\n";
+    }
+}

--- a/examples/universal/z_put.cxx
+++ b/examples/universal/z_put.cxx
@@ -70,7 +70,12 @@ int _main(int argc, char **argv) {
     printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
     PutOptions options;
     options.set_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);
-
+#ifdef ZENOHCXX_ZENOHC
+    std::map<std::string, std::string> amap;
+    amap.insert(std::make_pair("serial_number", "123"));
+    amap.insert(std::make_pair("coordinates", "48.7082,2.1498"));
+    options.set_attachment(amap);
+#endif
     if (!session.put(keyexpr, value, options)) {
         printf("Put failed...\n");
     }

--- a/examples/universal/z_queryable_attachment.cxx
+++ b/examples/universal/z_queryable_attachment.cxx
@@ -1,0 +1,123 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <iostream>
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#define sleep(x) Sleep(x * 1000)
+#else
+#include <unistd.h>
+#endif
+
+#include "../getargs.h"
+#include "zenoh.hxx"
+using namespace zenoh;
+
+#ifdef ZENOHCXX_ZENOHC
+const char *expr = "demo/example/zenoh-cpp-zenoh-c-queryable";
+const char *value = "Queryable from C++ zenoh-c!";
+#elif ZENOHCXX_ZENOHPICO
+const char *expr = "demo/example/zenoh-cpp-zenoh-pico-queryable";
+const char *value = "Queryable from C++ zenoh-pico!";
+#else
+#error "Unknown zenoh backend"
+#endif
+
+int _main(int argc, char **argv) {
+    const char *configfile = nullptr;
+    getargs(argc, argv, {}, {{"key expression", &expr}, {"value", &value}}
+#ifdef ZENOHCXX_ZENOHC
+            ,
+            {{"-c", {"config file", &configfile}}}
+#endif
+    );
+
+    Config config;
+#ifdef ZENOHCXX_ZENOHC
+    if (configfile) {
+        config = expect(config_from_file(configfile));
+    }
+#endif
+
+    printf("Opening session...\n");
+    auto session = expect<Session>(open(std::move(config)));
+
+    KeyExprView keyexpr(expr);
+    if (!keyexpr.check()) {
+        printf("%s is not a valid key expression", expr);
+        exit(-1);
+    }
+
+    printf("Declaring Queryable on '%s'...\n", expr);
+
+    auto on_query = [](const Query &query) {
+        auto keystr = query.get_keyexpr();
+        auto pred = query.get_parameters();
+        auto query_value = query.get_value();
+        std::cout << ">> [Queryable ] Received Query '" << keystr.as_string_view() << "?" << pred.as_string_view()
+                  << "' value = '" << query_value.as_string_view() << "'\n";
+
+#ifdef ZENOHCXX_ZENOHC
+        std::map<std::string, std::string> amap;
+        if (query.get_attachment().check()) {
+            // reads full attachment
+            query.get_attachment().iterate([&amap](const BytesView &key, const BytesView &value) -> bool {
+                // process attachment and prepare a modified version for the reply
+                std::string new_value("echo ");
+                new_value += value.as_string_view();
+                amap[std::string(key.as_string_view())] = new_value;
+                return true;
+            });
+
+            // reads particular attachment item
+            auto index = query.get_attachment().get("source");
+            if (index != "") {
+                std::cout << "   event source: " << index.as_string_view() << std::endl;
+            }
+        }
+#endif
+        QueryReplyOptions options;
+        options.set_encoding(Encoding(Z_ENCODING_PREFIX_TEXT_PLAIN));
+#ifdef ZENOHCXX_ZENOHC
+        // set map as an attachment
+        options.set_attachment(amap);
+#endif
+        query.reply(expr, value, options);
+    };
+
+    auto on_drop_queryable = []() { std::cout << "Destroying queryable\n"; };
+
+    auto queryable = expect<Queryable>(session.declare_queryable(keyexpr, {on_query, on_drop_queryable}));
+
+    printf("Enter 'q' to quit...\n");
+    int c = 0;
+    while (c != 'q') {
+        c = getchar();
+        if (c == -1) {
+            sleep(1);
+        }
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    try {
+        _main(argc, argv);
+    } catch (ErrorMessage e) {
+        std::cout << "Received an error :" << e.as_string_view() << "\n";
+    }
+}

--- a/examples/universal/z_sub_attachment.cxx
+++ b/examples/universal/z_sub_attachment.cxx
@@ -1,0 +1,108 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#include <stdio.h>
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#define sleep(x) Sleep(x * 1000)
+#else
+#include <unistd.h>
+#endif
+#include <iostream>
+
+#include "../getargs.h"
+#include "zenoh.hxx"
+using namespace zenoh;
+
+const char *kind_to_str(z_sample_kind_t kind);
+
+int _main(int argc, char **argv) {
+    const char *expr = "demo/example/**";
+    const char *configfile = nullptr;
+
+    getargs(argc, argv, {}, {{"key expression", &expr}}
+#ifdef ZENOHCXX_ZENOHC
+            ,
+            {{"-c", {"config file", &configfile}}}
+#endif
+    );
+
+    Config config;
+#ifdef ZENOHCXX_ZENOHC
+    if (configfile) {
+        config = expect(config_from_file(configfile));
+    }
+#endif
+
+    KeyExprView keyexpr(expr);
+
+    std::cout << "Opening session..." << std::endl;
+    auto session = expect<Session>(open(std::move(config)));
+
+    auto data_handler = [](const Sample &sample) {
+        std::cout << ">> [Subscriber] Received " << kind_to_str(sample.get_kind()) << " ('"
+                  << sample.get_keyexpr().as_string_view() << "' : '" << sample.get_payload().as_string_view()
+                  << "')\n";
+#ifdef ZENOHCXX_ZENOHC
+        if (sample.get_attachment().check()) {
+            // reads full attachment
+            sample.get_attachment().iterate([](const BytesView &key, const BytesView &value) -> bool {
+                std::cout << "   attachment: " << key.as_string_view() << ": '" << value.as_string_view() << "'\n";
+                return true;
+            });
+
+            // reads particular attachment item
+            auto index = sample.get_attachment().get("index");
+            if (index != "") {
+                std::cout << "   message number: " << index.as_string_view() << std::endl;
+            }
+        }
+#endif
+    };
+
+    std::cout << "Declaring Subscriber on '" << keyexpr.as_string_view() << "'..." << std::endl;
+    auto subscriber = expect<Subscriber>(session.declare_subscriber(keyexpr, data_handler));
+#ifdef ZENOHCXX_ZENOHC
+    std::cout << "Subscriber on '" << subscriber.get_keyexpr().as_string_view() << "' declared" << std::endl;
+#endif
+
+    printf("Enter 'q' to quit...\n");
+    int c = 0;
+    while (c != 'q') {
+        c = getchar();
+        if (c == -1) {
+            sleep(1);
+        }
+    }
+
+    return 0;
+}
+
+const char *kind_to_str(z_sample_kind_t kind) {
+    switch (kind) {
+        case Z_SAMPLE_KIND_PUT:
+            return "PUT";
+        case Z_SAMPLE_KIND_DELETE:
+            return "DELETE";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+int main(int argc, char **argv) {
+    try {
+        _main(argc, argv);
+    } catch (ErrorMessage e) {
+        std::cout << "Received an error :" << e.as_string_view() << "\n";
+    }
+}

--- a/include/zenohcxx/impl.hxx
+++ b/include/zenohcxx/impl.hxx
@@ -719,3 +719,12 @@ inline bool z::Session::keyexpr_intersects(const z::KeyExprView& a, const z::Key
     ErrNo error;
     return z::Session::keyexpr_intersects(a, b, error);
 }
+
+#ifdef __ZENOHCXX_ZENOHC
+inline bool AttachmentView::iterate(const AttachmentView::IterBody& body) const {
+    auto cbody = [](struct z_bytes_t key, struct z_bytes_t value, void* context) -> int8_t {
+        return (*(static_cast<const IterBody*>(context)))(key, value) == 0;
+    };
+    return ::z_attachment_iterate(*this, cbody, const_cast<IterBody*>(&body)) == 0;
+}
+#endif  // ifdef __ZENOHCXX_ZENOHC

--- a/tests/zenohc/attachment.cxx
+++ b/tests/zenohc/attachment.cxx
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#include <map>
+#include <string>
+
+#include "zenohc.hxx"
+
+using namespace zenohc;
+
+#undef NDEBUG
+#include <assert.h>
+
+void writting_through_map_read_by_get() {
+    // Writing
+    std::map<std::string, std::string> amap;
+    amap.insert(std::make_pair("k1", "v1"));
+    amap.insert(std::make_pair("k2", "v2"));
+    AttachmentView attachment(amap);
+
+    // Elements check
+    assert(attachment.get("k1").check());
+    assert(attachment.get("k2").check());
+    assert(!attachment.get("k_non").check());
+
+    assert(attachment.get("k1").as_string_view() == "v1");
+    assert(attachment.get("k2").as_string_view() == "v2");
+}
+
+bool _attachment_reader(const BytesView& key, const BytesView& value,
+                        const std::vector<std::pair<std::string, std::string>>& test_data) {
+    for (const auto& it : test_data) {
+        if (it.first == key.as_string_view()) {
+            assert(it.second == value.as_string_view());
+            return true;
+        }
+    }
+    assert(!"Unexpected");
+}
+
+void writting_through_map_read_by_iter_func() {
+    std::vector<std::pair<std::string, std::string>> test_data;
+    test_data.push_back(std::make_pair("k1", "v1"));
+    test_data.push_back(std::make_pair("k2", "v2"));
+    test_data.push_back(std::make_pair("k3", "v3"));
+
+    // Writing
+    std::map<std::string, std::string> amap;
+    AttachmentView attachment(amap);
+
+    // amap passed by reference we can change it after
+    for (auto it : test_data) {
+        amap.insert(std::make_pair(it.first, it.second));
+    }
+
+    // Elements check as function
+    using namespace std::placeholders;
+    attachment.iterate(std::bind(_attachment_reader, _1, _2, test_data));
+}
+
+void writting_through_map_read_by_iter_lambda() {
+    std::vector<std::pair<std::string, std::string>> test_data;
+    test_data.push_back(std::make_pair("k1", "v1"));
+    test_data.push_back(std::make_pair("k2", "v2"));
+    test_data.push_back(std::make_pair("k3", "v3"));
+
+    // Writing
+    std::map<std::string, std::string> amap;
+    AttachmentView attachment(amap);
+
+    // amap passed by reference we can change it after
+    for (auto it : test_data) {
+        amap.insert(std::make_pair(it.first, it.second));
+    }
+
+    // Elements check as lambda
+    using namespace std::placeholders;
+    attachment.iterate([&test_data](const BytesView& key, const BytesView& value) {
+        for (const auto& it : test_data) {
+            if (it.first == key.as_string_view()) {
+                assert(it.second == value.as_string_view());
+                return true;
+            }
+        }
+        assert(!"Unexpected");
+    });
+}
+
+void writting_no_map_read_by_get() {
+    std::vector<std::pair<std::string, std::string>> test_data;
+    test_data.push_back(std::make_pair("k1", "v1"));
+    test_data.push_back(std::make_pair("k2", "v2"));
+    test_data.push_back(std::make_pair("k3", "v3"));
+
+    AttachmentView::IterDriver driver([&test_data](const AttachmentView::IterBody& body) -> bool {
+        for (const auto& it : test_data) {
+            if (body(BytesView(it.first), BytesView(it.second))) {
+                return true;
+            }
+        }
+        return false;
+    });
+
+    AttachmentView attachment(driver);
+
+    // Elements check
+    for (auto it : test_data) {
+        assert(attachment.get(it.first).check());
+        assert(attachment.get(it.first).as_string_view() == it.second);
+    }
+    assert(!attachment.get("k_non").check());
+}
+
+int main(int argc, char** argv) {
+    init_logger();
+    writting_through_map_read_by_get();
+    writting_through_map_read_by_iter_func();
+    writting_through_map_read_by_iter_lambda();
+    writting_no_map_read_by_get();
+}


### PR DESCRIPTION
Implement [attachment api](https://github.com/eclipse-zenoh/zenoh/pull/613) support "C++" binding
Currently only for [zeno-c](https://github.com/eclipse-zenoh/zenoh-c/pull/203), zenoh-pico support will coming soon.

Allows add attachment to pub/sub/query/reply.

Adds AttachmentView class with tests (attachment.cxx)

Adds examples:
 - z_get_attachment.cxx
 - z_pub_attachment.cxx
 - z_queryable_attachment.cxx
 - z_sub_attachment.cxx
