### PR TITLE
move publisher and subscriber get_keyexpr implementation from impl.hxx to api.hxx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,40 +19,35 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          path: zenoh-cpp
 
       - name: install zenoh-cpp
         shell: bash
         run: |
           mkdir -p build_install && cd build_install
-          cmake ../install -DCMAKE_INSTALL_PREFIX=~/local
+          cmake ../zenoh-cpp/install -DCMAKE_INSTALL_PREFIX=~/local
           cmake --install .
 
       - name: make examples
         shell: bash
         run: |
           mkdir -p build && cd build
-          cmake ..
+          cmake ../zenoh-cpp
           cmake --build . --target examples
 
       - name: make examples with zenoh-cpp as subbroject
         shell: bash
         run: |
           mkdir -p build_examples_subproj && cd build_examples_subproj
-          cmake ../examples -DCMAKE_BUILD_TYPE=Debug
+          cmake ../zenoh-cpp/examples -DCMAKE_BUILD_TYPE=Debug
           cmake --build . --config Debug
 
       - name: make examples with zenoh-cpp as installed package
         shell: bash
         run: |
           mkdir -p build_examples_findproj && cd build_examples_findproj
-          cmake ../examples -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHCXX_SOURCE=PACKAGE
-          cmake --build . --config Release
-
-      - name: make standalone example with zenoh-cpp as installed package
-        shell: bash
-        run: |
-          mkdir -p build_examples_standalone_findproj && cd build_examples_standalone_findproj
-          cmake ../examples/standalone -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHCXX_SOURCE=PACKAGE
+          cmake ../zenoh-cpp/examples -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHCXX_SOURCE=PACKAGE
           cmake --build . --config Release
 
       - name: make tests
@@ -68,6 +63,28 @@ jobs:
         run: |
           cd build
           ctest
+
+      # build zenoh-c and standalone project that needs zenoh-cpp and zenoh-c
+      # probably this belongs in a different action yaml
+      - name: get zenoh-c
+        uses: actions/checkout@v3
+        with:
+          repository: eclipse-zenoh/zenoh-c
+          path: zenoh-c
+
+      - name: install zenoh-c
+        shell: bash
+        run: |
+          mkdir -p zenohc_build_install && cd zenohc_build_install
+          cmake ../zenoh-c -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local
+          cmake --build . --target install --config Release
+
+      - name: make standalone example with zenoh-cpp as installed package
+        shell: bash
+        run: |
+          mkdir -p build_examples_standalone_findproj && cd build_examples_standalone_findproj
+          cmake ../zenoh-cpp/examples/standalone -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local
+          cmake --build . --config Release
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ jobs:
           cmake ../examples -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHCXX_SOURCE=PACKAGE
           cmake --build . --config Release
 
+      - name: make standalone example with zenoh-cpp as installed package
+        shell: bash
+        run: |
+          mkdir -p build_examples_standalone_findproj && cd build_examples_standalone_findproj
+          cmake ../examples/standalone -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHCXX_SOURCE=PACKAGE
+          cmake --build . --config Release
+
       - name: make tests
         shell: bash
         run: |

--- a/examples/standalone/CMakeLists.txt
+++ b/examples/standalone/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(zenoh_foo)
+
+find_package(zenohc REQUIRED)
+find_package(zenohcxx REQUIRED)
+
+add_executable(foo main.cpp foo.cpp)
+target_link_libraries(foo zenohcxx::zenohc::lib)
+set_property(TARGET foo PROPERTY CXX_STANDARD 17)

--- a/examples/standalone/foo.cpp
+++ b/examples/standalone/foo.cpp
@@ -1,0 +1,4 @@
+#include <iostream>
+#include <zenohc.hxx>
+
+#include "foo.hpp"

--- a/examples/standalone/foo.hpp
+++ b/examples/standalone/foo.hpp
@@ -1,0 +1,6 @@
+#ifndef FOO_HXX
+#define FOO_HXX
+
+#include "zenohc.hxx"
+
+#endif  // FOO_HXX

--- a/examples/standalone/main.cpp
+++ b/examples/standalone/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+
+#include <zenohc.hxx>
+
+#include "foo.hpp"
+
+int main()
+{
+  return 0;
+}

--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -1616,7 +1616,7 @@ class Subscriber : public Owned<::z_owned_subscriber_t> {
 #ifdef __ZENOHCXX_ZENOHC
     /// @brief Get the key expression of the subscriber
     /// @return ``zenoh::KeyExpr`` value
-    z::KeyExpr get_keyexpr() const;
+    z::KeyExpr get_keyexpr() const { return ::z_subscriber_keyexpr(loan()); }
 #endif
 };
 
@@ -1701,7 +1701,7 @@ class Publisher : public Owned<::z_owned_publisher_t> {
 #ifdef __ZENOHCXX_ZENOHC
     /// @brief Get the key expression of the publisher
     /// @return ``zenoh::KeyExpr`` value
-    z::KeyExpr get_keyexpr() const;
+    z::KeyExpr get_keyexpr() const { return ::z_publisher_keyexpr(loan()); }
 #endif
 
 #ifdef __ZENOHCXX_ZENOHC

--- a/include/zenohcxx/impl.hxx
+++ b/include/zenohcxx/impl.hxx
@@ -313,14 +313,6 @@ inline bool z::Publisher::put_owned_impl(z::Payload&& payload, const z::Publishe
 
 #endif
 
-#ifdef __ZENOHCXX_ZENOHC
-z::KeyExpr z::Publisher::get_keyexpr() const { return ::z_publisher_keyexpr(loan()); }
-#endif
-
-#ifdef __ZENOHCXX_ZENOHC
-z::KeyExpr z::Subscriber::get_keyexpr() const { return ::z_subscriber_keyexpr(loan()); }
-#endif
-
 inline bool scout(z::ScoutingConfig&& config, ClosureHello&& callback, ErrNo& error) {
     auto c = config.take();
     auto cb = callback.take();


### PR DESCRIPTION
I haven't tested much (`ctest` tests all passed locally for me though) but this appears to solve the linker issue in https://github.com/eclipse-zenoh/roadmap/discussions/105

All the other get_keyexpr() implementations were already in api.hxx and not impl.hxx, so this matches this pattern (but maybe not the intent of the api-impl split).