### PR TITLE
Fix Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,14 @@ on:
     - cron: "0 0 * * 1-5"
   workflow_dispatch:
 
-
 jobs:
   preps:
     name: Preparation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
       - name: Environment setup
         id: env
         shell: bash
@@ -66,13 +67,16 @@ jobs:
     needs: preps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
       - name: Make packages
         shell: bash
         run: |
           mkdir -p build && cd build
           cmake ../install -DCPACK_PACKAGE_VERSION=${{ needs.preps.outputs.PKG_VERSION }}
           cmake --build . --target package
+
       - name: Packaging
         id: package
         shell: bash
@@ -91,8 +95,9 @@ jobs:
           zip ${DEB_PKG_NAME} *.deb
           echo "Packaging ${RPM_PKG_NAME}:"
           zip ${RPM_PKG_NAME} *.rpm
+
       - name: "Upload packages"
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3
         with:
           name: Upload packages
           path: |
@@ -107,13 +112,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download result of previous builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: ARTIFACTS
+
       - name: Publish as github release
         uses: softprops/action-gh-release@v1
         with:
           files: ARTIFACTS/*/*.*
+
       - name: Publish to download.eclipse.org/zenoh
         env:
           SSH_TARGET: genie.zenoh@projects-storage.eclipse.org


### PR DESCRIPTION
This bumps `actions/download-artifact@v2` to `actions/download-artifact@v3` because (1) it used a deprecated version of node (`node12`) and (2) it is out of sync with its `actions/upload-artifact@v3` counterpart.