### PR TITLE
Align examples and remove reading from stdin

### DIFF
--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -88,7 +88,8 @@ int _main(int argc, char **argv) {
 
     PublisherPutOptions options;
     options.set_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);
-    for (int idx = 0; std::numeric_limits<int>::max(); ++idx) {
+    std::cout << "Press CTRL-C to quit..." << std::endl;
+    for (int idx = 0; idx < std::numeric_limits<int>::max(); ++idx) {
         sleep(1);
         std::ostringstream ss;
         ss << "[" << idx << "] " << value;

--- a/examples/universal/z_pub_attachment.cxx
+++ b/examples/universal/z_pub_attachment.cxx
@@ -79,7 +79,8 @@ int _main(int argc, char **argv) {
     // add some value
     amap.insert(std::pair("source", "C++"));
 #endif
-    for (int idx = 0; std::numeric_limits<int>::max(); ++idx) {
+    std::cout << "Press CTRL-C to quit..." << std::endl;
+    for (int idx = 0; idx < std::numeric_limits<int>::max(); ++idx) {
         sleep(1);
         std::ostringstream ss;
         ss << "[" << idx << "] " << value;

--- a/examples/universal/z_pub_thr.cxx
+++ b/examples/universal/z_pub_thr.cxx
@@ -62,6 +62,7 @@ int _main(int argc, char **argv) {
     printf("Declaring Publisher on '%s'...\n", keyexpr);
     auto pub = expect<Publisher>(session.declare_publisher(keyexpr, options));
 
+    printf("Press CTRL-C to quit...\n");
     while (1) pub.put(payload);
 }
 

--- a/examples/universal/z_pull.cxx
+++ b/examples/universal/z_pull.cxx
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #endif
 #include <iostream>
+#include <limits>
 
 #include "../getargs.h"
 #include "zenoh.hxx"
@@ -75,15 +76,11 @@ int _main(int argc, char **argv) {
     printf("Declaring Subscriber on '%s'...\n", expr);
     auto subscriber = expect<PullSubscriber>(session.declare_pull_subscriber(keyexpr, data_handler));
 
-    printf("Press <enter> to pull data...\n");
-    int c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            sleep(1);
-        } else {
-            subscriber.pull();
-        }
+    printf("Press CTRL-C to quit...\n");
+    for (int idx = 0; idx < std::numeric_limits<int>::max(); ++idx) {
+        sleep(1);
+        printf("[%4d] Pulling...\n", idx);
+        subscriber.pull();
     }
 
     return 0;

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -95,13 +95,9 @@ int _main(int argc, char **argv) {
 
     auto queryable = expect<Queryable>(session.declare_queryable(keyexpr, {on_query, on_drop_queryable}));
 
-    printf("Enter 'q' to quit...\n");
-    int c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            sleep(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        sleep(1);
     }
 
     return 0;

--- a/examples/universal/z_queryable_attachment.cxx
+++ b/examples/universal/z_queryable_attachment.cxx
@@ -102,13 +102,9 @@ int _main(int argc, char **argv) {
 
     auto queryable = expect<Queryable>(session.declare_queryable(keyexpr, {on_query, on_drop_queryable}));
 
-    printf("Enter 'q' to quit...\n");
-    int c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            sleep(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        sleep(1);
     }
 
     return 0;

--- a/examples/universal/z_sub.cxx
+++ b/examples/universal/z_sub.cxx
@@ -77,13 +77,9 @@ int _main(int argc, char **argv) {
     std::cout << "Subscriber on '" << subscriber.get_keyexpr().as_string_view() << "' declared" << std::endl;
 #endif
 
-    printf("Enter 'q' to quit...\n");
-    int c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            sleep(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        sleep(1);
     }
 
     return 0;

--- a/examples/universal/z_sub_attachment.cxx
+++ b/examples/universal/z_sub_attachment.cxx
@@ -76,13 +76,9 @@ int _main(int argc, char **argv) {
     std::cout << "Subscriber on '" << subscriber.get_keyexpr().as_string_view() << "' declared" << std::endl;
 #endif
 
-    printf("Enter 'q' to quit...\n");
-    int c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            sleep(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        sleep(1);
     }
 
     return 0;

--- a/examples/universal/z_sub_thr.cxx
+++ b/examples/universal/z_sub_thr.cxx
@@ -13,6 +13,12 @@
 //
 #include <stdio.h>
 #include <chrono>
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#define sleep(x) Sleep(x * 1000)
+#else
+#include <unistd.h>
+#endif
 
 #include "../getargs.h"
 #include "zenoh.hxx"
@@ -98,10 +104,12 @@ int _main(int argc, char **argv) {
 
     Stats stats;
     auto subscriber = expect<Subscriber>(session.declare_subscriber(keyexpr, {stats, stats}));
-    char c = 0;
-    while (c != 'q') {
-        c = fgetc(stdin);
+
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        sleep(1);
     }
+
     subscriber.drop();
     stats.print();
 


### PR DESCRIPTION
These changes remove reading from stdin for all examples, and align their behaviors and outputs across projects.

This PR is part of an effort across currently active Zenoh projects. To maintain examples' implementations as close to each other as possible, any changes identified in other projects will be replicated in this PR. As such, **please do not merge these changes until all PRs are ready for merging**.
