### PR TITLE
main branch reference added to examples, misprint in pico example fixed

### DIFF
--- a/examples/simple/universal/CMakeLists.txt
+++ b/examples/simple/universal/CMakeLists.txt
@@ -20,9 +20,9 @@ endif()
 #
 # 3. Use FetchContent:
 include(FetchContent)
-FetchContent_declare(zenohpico_backend GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-pico")
+FetchContent_declare(zenohpico_backend GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-pico" GIT_TAG main)
 FetchContent_MakeAvailable(zenohpico_backend)
-FetchContent_declare(zenohc_backend GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c")
+FetchContent_declare(zenohc_backend GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c" GIT_TAG main)
 FetchContent_MakeAvailable(zenohc_backend)
 FetchContent_declare(cpp_wrapper GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-cpp" GIT_TAG main)
 FetchContent_MakeAvailable(cpp_wrapper)

--- a/examples/simple/zenohc/CMakeLists.txt
+++ b/examples/simple/zenohc/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 include(FetchContent)
 
-FetchContent_declare(c_backend GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c")
+FetchContent_declare(c_backend GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c" GIT_TAG main)
 FetchContent_MakeAvailable(c_backend)
 FetchContent_declare(cpp_wrapper GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-cpp" GIT_TAG main)
 FetchContent_MakeAvailable(cpp_wrapper)

--- a/examples/simple/zenohpico/CMakeLists.txt
+++ b/examples/simple/zenohpico/CMakeLists.txt
@@ -7,12 +7,12 @@ endif()
 
 include(FetchContent)
 
-FetchContent_declare(c_backend GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-pico")
+FetchContent_declare(c_backend GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-pico" GIT_TAG main)
 FetchContent_MakeAvailable(c_backend)
 FetchContent_declare(cpp_wrapper GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-cpp" GIT_TAG main)
 FetchContent_MakeAvailable(cpp_wrapper)
 
-add_executable(zp_auto zp_simple.cxx)
-target_link_libraries(zp_auto PRIVATE zenohcxx::zenohpico)
+add_executable(zp_simple zp_simple.cxx)
+target_link_libraries(zp_simple PRIVATE zenohcxx::zenohpico)
 set_property(TARGET zp_simple PROPERTY LANGUAGE CXX)
 set_property(TARGET zp_simple PROPERTY CXX_STANDARD 17)


### PR DESCRIPTION
Fix compilation failure in example because of takinh master branch by default.

It seems reasonable to completely remove `master` branch in zenoh projects, this causes error because `master` is selected by default by some tools, like `FetchContent_declare` in CMake