### PR TITLE
fix: Add workflow_dispatch trigger to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: ["**"]
   schedule:
     - cron: "0 6 * * 1-5"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This way we can manually trigger the workflow when needed