### PR TITLE
chore: Update artifacts action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           ctest
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # Artifact name
           name: zenoh-cpp-${{ matrix.os }}


### PR DESCRIPTION
artifacts actions v3 are deprecated