### PR TITLE
Define NOMINMAX in z_pull to use std::max

### DIFF
--- a/examples/universal/z_pull.cxx
+++ b/examples/universal/z_pull.cxx
@@ -13,6 +13,7 @@
 //
 #include <stdio.h>
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#define NOMINMAX
 #include <windows.h>
 #define sleep(x) Sleep(x * 1000)
 #else


### PR DESCRIPTION
Without this change, the `z_pull_zenohc` example fails on Visual Studio 2022 with the error:

~~~
(zenohcppwin) D:\src\zenoh-cpp\examples\build2022>cmake --build . --config Release --target z_pull_zenohc
MSBuild version 17.10.4+10fbfbf2e for .NET Framework

  z_pull.cxx
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(81,55): warning C4003: not enough arguments for function-like macro invo
cation 'max' [D:\src\zenoh-cpp\examples\build2022\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(81,55): error C2589: '(': illegal token on right side of '::' [D:\src\ze
noh-cpp\examples\build2022\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(81,29): error C2062: type 'unknown-type' unexpected [D:\src\zenoh-cpp\ex
amples\build2022\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(81,67): error C2059: syntax error: ')' [D:\src\zenoh-cpp\examples\build2
022\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(82,17): error C2059: syntax error: ';' [D:\src\zenoh-cpp\examples\build2
022\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(87,5): error C2059: syntax error: 'return' [D:\src\zenoh-cpp\examples\bu
ild2022\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(88,1): error C2059: syntax error: '}' [D:\src\zenoh-cpp\examples\build20
22\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(88,1): error C2143: syntax error: missing ';' before '}' [D:\src\zenoh-c
pp\examples\build2022\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(90,42): error C2143: syntax error: missing ';' before '{' [D:\src\zenoh-
cpp\examples\build2022\z_pull_zenohc.vcxproj]
D:\src\zenoh-cpp\examples\universal\z_pull.cxx(90,42): error C2447: '{': missing function header (old-style formal list
?) [D:\src\zenoh-cpp\examples\build2022\z_pull_zenohc.vcxproj]
~~~

The problem is that including `windows.h` defines the `max` preprocessor macro, that interferes with the subsequent use of `std::max` . By defining `NOMINMAX` , no `max` macros is defined.

With this and https://github.com/eclipse-zenoh/zenoh-cpp/pull/134, all the `zenohc` based examples compile fine on Visual Studio 2022 (xref: https://github.com/eclipse-zenoh/zenoh-cpp/issues/5), while the `zenohpico` one are still failing.