### PR TITLE
Rename ambiguous _iter_driver and pair_contained

### DIFF
--- a/include/zenohcxx/api.hxx
+++ b/include/zenohcxx/api.hxx
@@ -709,8 +709,8 @@ struct AttachmentView : public Copyable<::z_attachment_t> {
     AttachmentView(const AttachmentView::IterDriver& _iter_driver)
         : Copyable({static_cast<const void*>(&_iter_driver),
                     [](const void* data, z_attachment_iter_body_t body, void* ctx) -> int8_t {
-                        const IterDriver* _iter_driver = static_cast<const IterDriver*>(data);
-                        return (*_iter_driver)([&body, &ctx](const BytesView& key, const BytesView& value) {
+                        const IterDriver* _iter_driver_ptr = static_cast<const IterDriver*>(data);
+                        return (*_iter_driver_ptr)([&body, &ctx](const BytesView& key, const BytesView& value) {
                             return body(key, value, ctx);
                         });
                     }}) {}
@@ -722,8 +722,8 @@ struct AttachmentView : public Copyable<::z_attachment_t> {
     AttachmentView(const T& pair_container)
         : Copyable({static_cast<const void*>(&pair_container),
                     [](const void* data, z_attachment_iter_body_t body, void* ctx) -> int8_t {
-                        const T* pair_container = static_cast<const T*>(data);
-                        for (const auto& it : *pair_container) {
+                        const T* pair_container_ptr = static_cast<const T*>(data);
+                        for (const auto& it : *pair_container_ptr) {
                             int8_t ret = body(BytesView(it.first), BytesView(it.second), ctx);
                             if (ret) {
                                 return ret;


### PR DESCRIPTION
In the `AttachView` containers, the variables `_iter_driver` and `pair_container` was used to refer to both a reference argument passed to the container, and also to a pointer local variable that was defined inside a lamba function passed to a delating constructor. 

In general this may not be readable, but on Windows with Visual Studio 2022 (cl.exe version: 19.29.30153) this also creates a compilation error:

~~~
D:\src\zenoh-cpp\include\zenohcxx\api.hxx(713,34): error C3493: '_iter_driver' cannot be implicitly captured because no default capture mode has been specified [D:\src\zenoh-cpp\examples\build2022\z_simple_zenohc.vcxproj]
D:\src\zenoh-cpp\include\zenohcxx\api.hxx(726,48): error C3493: 'pair_container' cannot be implicitly captured because no default capture mode has been spe
cified [D:\src\zenoh-cpp\examples\build2022\z_pub_attachment_zenohc.vcxproj]
~~~

This PR solves both the compilation problem (and the general readability problem) by renaming the local variables to a different name.