### PR TITLE
Determine debian architecture using dpkg

### DIFF
--- a/install/CMakeLists.txt
+++ b/install/CMakeLists.txt
@@ -79,7 +79,11 @@ set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
 if(UNIX)
   # DEB package
   if(NOT DEBARCH)
-    set(DEBARCH ${CMAKE_SYSTEM_PROCESSOR})
+    execute_process(
+      COMMAND dpkg --print-architecture
+      OUTPUT_VARIABLE DEBARCH
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
   endif()
   message(STATUS "Configure DEB packaging for Linux ${DEBARCH}")
   list(APPEND CPACK_GENERATOR DEB)


### PR DESCRIPTION
The architecture in the Debian packages in the Github releases is x86_64, which is not a valid Debian architecture:
`➜ sudo dpkg -i packages/zenoh-cpp-0.11.0.0.deb
dpkg: warning: parsing file '/var/lib/dpkg/tmp.ci/control' near line 1:
 'x86_64' is not a valid architecture name in 'Architecture' field: character '_' not allowed (only letters, digits and characters '-')
dpkg: error processing archive packages/zenoh-cpp-0.11.0.0.deb (--install):
 package architecture (x86_64) does not match system (amd64)
Errors were encountered while processing:
 packages/zenoh-cpp-0.11.0.0.deb`

See also https://wiki.debian.org/SupportedArchitectures

Instead using dpkg --print-architecture (or any other way if you dont want to have a dependency on dpkg) to determine the architecture provides the correct architecture (amd64):
`➜ sudo dpkg -i packages/zenoh-cpp-0.11.0.0.deb
(Reading database ... 626979 files and directories currently installed.)
Preparing to unpack .../zenoh-cpp-0.11.0.0.deb ...
Unpacking zenoh-cpp (0.11.0.0) over (0.11.0.0) ...
Setting up zenoh-cpp (0.11.0.0) ...
`
