### PR TITLE
Cmake fixes dev 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,16 @@ project(
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 include(helpers)
 
+set(project_version "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+if(NOT DEFINED PROJECT_VERSION_TWEAK)
+	set(project_version "${project_version}")
+elseif(PROJECT_VERSION_TWEAK EQUAL 0)
+	set(project_version "${project_version}-dev")
+elseif(PROJECT_VERSION_TWEAK GREATER 1)
+	set(project_version "${project_version}-pre.${PROJECT_VERSION_TWEAK}")
+endif()
+status_print(project_version)
+
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 	# Temporary measure. Ideally zenoh-cpp should work with any variant
 	# of zenoh-c build


### PR DESCRIPTION
Cherry-pick changes from main into dev/1.0.0

As per https://github.com/eclipse-zenoh/zenoh-c/pull/466, align how we configure zenoh CMake based projects version.