### PR TITLE
Adding missing options to put

### DIFF
--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -95,7 +95,7 @@ int _main(int argc, char **argv) {
         ss << "[" << idx << "] " << value;
         auto s = ss.str();  // in C++20 use .view() instead
         std::cout << "Putting Data ('" << keyexpr << "': '" << s << "')...\n";
-        pub.put(s);
+        pub.put(s, options);
     }
     return 0;
 }


### PR DESCRIPTION
Somewhere along the road, the PublisherPutOptions was forgotten in one of the examples.
I thought it did not look good, and I felt bad for the mission option.
So now I included it in the "put", which I think was the original intention.