### PR TITLE
remove EntityGlobalIdConstructor since it is no longer exposed in zenoh-c

### DIFF
--- a/include/zenoh/api/source_info.hxx
+++ b/include/zenoh/api/source_info.hxx
@@ -23,16 +23,8 @@ namespace zenoh {
 
 /// The global unique id of a Zenoh entity.
 class EntityGlobalId : public Copyable<::z_entity_global_id_t> {
+public:
     using Copyable::Copyable;
-
-    /// @name Constructors
-
-    /// @brief Create new entity global id.
-    EntityGlobalId(const Id& id, uint32_t eid) 
-        :Copyable({}) {
-        ::z_entity_global_id_new(&this->inner(), detail::as_copyable_c_ptr(id), eid);
-    }
-
     /// @name Methods
 
     /// Get Zenoh id.


### PR DESCRIPTION
remove EntityGlobalIdConstructor since it is no longer exposed in zenoh-c