### PR TITLE
add missing inline to Bytes::iter method

### DIFF
--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -261,7 +261,7 @@ public:
 
 };
 
-Bytes::Iterator Bytes::iter() const {
+inline Bytes::Iterator Bytes::iter() const {
     return Bytes::Iterator(::z_bytes_get_iterator(this->loan()));
 }
 


### PR DESCRIPTION
add missing inline to Bytes::iter() method