### PR TITLE
Allow implicit construction for KeyExpr and Bytes

### DIFF
--- a/examples/simple/zenohc/zc_simple.cxx
+++ b/examples/simple/zenohc/zc_simple.cxx
@@ -19,5 +19,5 @@ using namespace zenoh;
 int main(int, char **) {
     Config config = Config::create_default();
     auto session = Session::open(std::move(config));
-    session.put(KeyExpr("demo/example/simple"), Bytes::serialize("Simple!"));
+    session.put("demo/example/simple", "Simple!");
 }

--- a/examples/simple/zenohpico/zp_simple.cxx
+++ b/examples/simple/zenohpico/zp_simple.cxx
@@ -19,5 +19,5 @@ using namespace zenoh;
 int main(int, char **) {
     Config config = Config::create_default();
     auto session = Session::open(std::move(config));
-    session.put(KeyExpr("demo/example/simple"), Bytes::serialize("Simple!"));
+    session.put("demo/example/simple", "Simple!");
 }

--- a/include/zenoh/api/base.hxx
+++ b/include/zenoh/api/base.hxx
@@ -78,7 +78,7 @@ protected:
 public:
     /// @name Constructors
     /// Construct from wrapped zenoh-c / zenoh-pico structure
-    Copyable(const InnerType& v) : _0(v) {}
+    explicit Copyable(const InnerType& v) : _0(v) {}
     explicit operator const ZC_COPYABLE_TYPE&() const { return inner(); }
     explicit operator ZC_COPYABLE_TYPE&() { return inner(); }
 };
@@ -95,7 +95,7 @@ public:
     /// @brief Construct from owned zenoh-c struct.
     /// @param pv Pointer to valid owned zenoh-c struct. The ownership is transferred
     /// to the constructed object.
-    Owned(OwnedType* pv) {
+    explicit Owned(OwnedType* pv) {
         if (pv) {
             _0 = *pv;
             ::z_null(pv);

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -55,9 +55,11 @@ class Bytes : public Owned<::z_owned_bytes_t> {
 public:
 
     /// @name Constructors
-    /// Serializes data using default Zenoh codec.
+
+    /// @brief Serializes data using default Zenoh codec.
     template<class T>
     Bytes(T data) :Bytes(Bytes::serialize(std::forward<T>(data))) {}
+    
     /// @brief Construct a shallow copy of this data.
     Bytes clone() const {
         Bytes b;

--- a/include/zenoh/api/hello.hxx
+++ b/include/zenoh/api/hello.hxx
@@ -31,7 +31,7 @@ public:
 
     /// @brief Get ``Id`` of the entity.
     /// @return ``Id`` of the entity.
-    Id get_id() const { return ::z_hello_zid(this->loan()); };
+    Id get_id() const { return Id(::z_hello_zid(this->loan())); };
 
     /// @brief Get the type of the entity.
     /// @return ``zenoh::WhatAmI`` of the entity.

--- a/include/zenoh/api/session.hxx
+++ b/include/zenoh/api/session.hxx
@@ -117,7 +117,7 @@ public:
     /// @param err if not null, the error code will be written to this location, otherwise ZException exception will be thrown in case of error.
     /// @return Declared ``KeyExpr`` instance.
     KeyExpr declare_keyexpr(const KeyExpr& key_expr, ZError* err = nullptr) const {
-        KeyExpr k(nullptr);
+        KeyExpr k;
         __ZENOH_ERROR_CHECK(
             ::z_declare_keyexpr(detail::as_owned_c_ptr(k), this->loan(), detail::loan(key_expr)),
             err,

--- a/include/zenoh/api/timestamp.hxx
+++ b/include/zenoh/api/timestamp.hxx
@@ -31,7 +31,7 @@ public:
 
     /// @brief Get the unique id of the timestamp.
     /// @return Id associated with this timestamp.
-    Id get_id() const { return ::z_timestamp_id(&this->inner()); }
+    Id get_id() const { return Id(::z_timestamp_id(&this->inner())); }
 };
 
 }

--- a/tests/universal/network/implicit.cxx
+++ b/tests/universal/network/implicit.cxx
@@ -1,0 +1,38 @@
+#include "zenoh.hxx"
+#include <thread>
+
+using namespace zenoh;
+using namespace std::chrono_literals;
+
+#undef NDEBUG
+#include <assert.h>
+
+void put_sub() {
+    auto session1 = Session::open(Config::create_default());
+    auto session2 = Session::open(Config::create_default());
+
+    std::this_thread::sleep_for(1s);
+
+    auto subscriber = session2.declare_subscriber("zenoh/test", channels::RingChannel(1));
+
+    std::this_thread::sleep_for(1s);
+
+    session1.put("zenoh/test", "data", {.attachment = std::vector<int32_t>{-1, 10, 15000}});
+
+    std::this_thread::sleep_for(1s);
+
+    auto [msg, alive] = subscriber.handler().recv();
+    assert(alive);
+    assert(msg.get_keyexpr() == "zenoh/test");
+    assert(msg.get_payload().deserialize<std::string>() == "data");
+    assert(msg.has_attachment());
+    assert((msg.get_attachment().deserialize<std::vector<int32_t>>() == std::vector<int32_t>{-1, 10, 15000}));
+}
+
+
+
+
+
+int main(int argc, char** argv) {
+    put_sub();
+}

--- a/tests/universal/network/keyexpr.cxx
+++ b/tests/universal/network/keyexpr.cxx
@@ -19,9 +19,6 @@ using namespace zenoh;
 
 
 void key_expr() {
-    KeyExpr nul(nullptr);
-    assert(!nul);
-
     KeyExpr foo("FOO");
     assert(static_cast<bool>(foo));
     assert(foo.as_string_view() == "FOO");
@@ -63,8 +60,6 @@ void join() {
 }
 
 void equals() {
-    KeyExpr nul(nullptr);
-
     KeyExpr foo("FOO");
     KeyExpr foo2("FOO");
     KeyExpr bar("BAR");


### PR DESCRIPTION
added  converting constructors from const char* and std::string for KeyExpr;
added converting constructors for Bytes;
Closes #155. Closes #156.