### PR TITLE
Revert "fix: use debian compatible arch"

### DIFF
--- a/install/CMakeLists.txt
+++ b/install/CMakeLists.txt
@@ -62,11 +62,7 @@ set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
 if(UNIX)
   # DEB package
   if(NOT DEBARCH)
-    execute_process(
-      COMMAND dpkg --print-architecture
-      OUTPUT_VARIABLE DEBARCH
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+    set(DEBARCH ${CMAKE_SYSTEM_PROCESSOR})
   endif()
   message(STATUS "Configure DEB packaging for Linux ${DEBARCH}")
   list(APPEND CPACK_GENERATOR DEB)


### PR DESCRIPTION
Reverts eclipse-zenoh/zenoh-cpp#161 to allow integrating #137 