### PR TITLE
fix: update ci build script

### DIFF
--- a/ci/scripts/build.bash
+++ b/ci/scripts/build.bash
@@ -16,7 +16,7 @@ readonly archive_rpm=$out/$repo_name-$version-rpm-pkgs.zip
 # Make packages into build/packages
 mkdir -p build
 cd build
-cmake ../install
+cmake -DZENOHCXX_ZENOHC=OFF ..
 cmake --build . --target package
 ls -R
 


### PR DESCRIPTION
On 0d77925bc92a2313d27a86f82d4067b92f729591 the build procedure for zenoh-cpp was updated so this needs to be updated as well.