### PR TITLE
Align with zenoh-c/pico

### DIFF
--- a/examples/universal/z_get_attachment.cxx
+++ b/examples/universal/z_get_attachment.cxx
@@ -57,10 +57,11 @@ int _main(int argc, char **argv) {
             const Sample& sample = reply.get_ok();
             std::cout << "Received ('" << sample.get_keyexpr().as_string_view() << "' : '"
                       << sample.get_payload().deserialize<std::string>() << "')\n";
-            if (!sample.has_attachment()) return;
+            auto attachment = sample.get_attachment();
+            if (!attachment.has_value()) return;
             // we expect attachment in the form of key-value pairs
-            auto attachment = sample.get_attachment().deserialize<std::unordered_map<std::string, std::string>>();
-            for (auto&& [key, value]: attachment) {
+            auto attachment_deserialized = attachment->get().deserialize<std::unordered_map<std::string, std::string>>();
+            for (auto&& [key, value]: attachment_deserialized) {
                 std::cout << "   attachment: " << key << ": '" << value << "'\n";
             }
         } else {

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -77,8 +77,12 @@ int _main(int argc, char **argv) {
     auto on_query = [](const Query &query) {
         const KeyExpr &keyexpr = query.get_keyexpr();
         auto params = query.get_parameters();
-        std::cout << ">> [Queryable ] Received Query '" << keyexpr.as_string_view() << "?" << params << "' value = '"
-                  << query.get_payload().deserialize<std::string>() << "'\n";
+        std::cout << ">> [Queryable ] Received Query '" << keyexpr.as_string_view() << "?" << params;
+        auto payload = query.get_payload();
+        if (payload.has_value()) {
+            std::cout << "' value = '" << payload->get().deserialize<std::string>();
+        }
+        std::cout << "'\n";
         query.reply(KeyExpr(expr), Bytes::serialize(value), {.encoding = Encoding("text/plain")});
     };
 

--- a/examples/universal/z_queryable_attachment.cxx
+++ b/examples/universal/z_queryable_attachment.cxx
@@ -60,13 +60,18 @@ int _main(int argc, char **argv) {
     auto on_query = [](const Query &query) {
         const KeyExpr& keyexpr = query.get_keyexpr();
         auto params = query.get_parameters();
-        std::cout << ">> [Queryable ] Received Query '" << keyexpr.as_string_view() << "?" << params
-                  << "' value = '" << query.get_payload().deserialize<std::string>() << "'\n";
+        auto payload = query.get_payload();
+        std::cout << ">> [Queryable ] Received Query '" << keyexpr.as_string_view() << "?" << params;
+        if (payload.has_value()) {
+            std::cout << "' value = '" << payload->get().deserialize<std::string>();
+        }
+        std::cout << "'\n";
 
         std::unordered_map<std::string, std::string> attachment_map;
-        if (query.has_attachment()) {
-            // reads attachment as a key-value map
-            attachment_map = query.get_attachment().deserialize<std::unordered_map<std::string, std::string>>();
+        auto attachment = query.get_attachment();
+        if (attachment.has_value()) {
+            // read attachment as a key-value map
+            attachment_map = attachment->get().deserialize<std::unordered_map<std::string, std::string>>();
             for (auto&& [key, value]: attachment_map) {
                 std::cout << "   attachment: " << key << ": '" << value << "'\n";
             }

--- a/examples/universal/z_sub_attachment.cxx
+++ b/examples/universal/z_sub_attachment.cxx
@@ -60,10 +60,11 @@ int _main(int argc, char **argv) {
         std::cout << ">> [Subscriber] Received " << kind_to_str(sample.get_kind()) << " ('"
                   << sample.get_keyexpr().as_string_view() << "' : '" << sample.get_payload().deserialize<std::string>()
                   << "')\n";
-        if (!sample.has_attachment()) return;
+        auto attachment = sample.get_attachment();
+        if (!attachment.has_value()) return;
         // we expect attachment in the form of key-value pairs
-        auto attachment = sample.get_attachment().deserialize<std::unordered_map<std::string, std::string>>();
-        for (auto&& [key, value]: attachment) {
+        auto attachment_data = attachment->get().deserialize<std::unordered_map<std::string, std::string>>();
+        for (auto&& [key, value]: attachment_data) {
             std::cout << "   attachment: " << key << ": '" << value << "'\n";
         }
     };

--- a/include/zenoh/api/config.hxx
+++ b/include/zenoh/api/config.hxx
@@ -88,6 +88,21 @@ class Config : public Owned<::z_owned_config_t> {
         __ZENOH_RESULT_CHECK(::z_config_client(&c._0, p.data(), p.size()), err, "Failed to create client config");
         return c;
     }
+
+    /// @brief Create a configuration by parsing a file with path stored in ZENOH_CONFIG environment variable.
+    /// @param res if not null, the result code will be written to this location, otherwise ZException exception will be
+    /// thrown in case of error.
+    /// @return the ``Config`` object.
+    /// @note zenoh-pico only.
+    static Config from_env(ZResult* err = nullptr) {
+        Config c(nullptr);
+        __ZENOH_RESULT_CHECK(
+            ::zc_config_from_env(&c._0),
+            err,
+            "Failed to create config from environment variable"
+        );
+        return c;
+    }
 #endif
 
 #ifdef ZENOHCXX_ZENOHPICO

--- a/include/zenoh/api/encoding.hxx
+++ b/include/zenoh/api/encoding.hxx
@@ -35,6 +35,12 @@ class Encoding : public Owned<::z_owned_encoding_t> {
                              std::string("Failed to create encoding from ").append(s));
     }
 
+    /// @brief Copy contructor
+    Encoding(const Encoding& other)
+        :Encoding() {
+        ::z_encoding_clone(&this->_0, other.loan());
+    };
+
     /// @name Methods
 
     /// @brief Get string representation of encoding.
@@ -45,6 +51,31 @@ class Encoding : public Owned<::z_owned_encoding_t> {
         ::z_drop(::z_move(s));
         return out;
     }
+
+#if defined(ZENOHCXX_ZENOHC)
+    /// @brief Set a schema to this encoding from a string.
+    /// 
+    /// Zenoh does not define what a schema is and its semantics is left to the implementer.
+    /// E.g. a common schema for `text/plain` encoding is `utf-8`.
+    void set_schema(std::string_view schema, ZResult* err = nullptr) {
+        __ZENOH_RESULT_CHECK(
+            ::z_encoding_set_schema_from_substr(this->loan(), schema.data(), schema.size()),
+            err,
+            "Failed to set encoding schema"
+        );
+    }
+#endif
+
+    /// @name Operators
+
+    /// @brief Assignment operator.
+    Encoding& operator=(const Encoding& other) {
+        if (this != &other) {
+            ::z_drop(z_move(this->_0));
+            ::z_encoding_clone(&this->_0, other.loan());
+        }
+        return *this;
+    };
 };
 
 }  // namespace zenoh

--- a/include/zenoh/api/sample.hxx
+++ b/include/zenoh/api/sample.hxx
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "base.hxx"
 #include "../detail/interop.hxx"
 #include "enums.hxx"
@@ -50,18 +52,12 @@ public:
     /// @return ``zenoh::SampleKind`` value (PUT or DELETE).
     SampleKind get_kind() const { return ::z_sample_kind(this->loan()); }
 
-    /// @brief Check if sample contains an attachment.
-    /// @return ``true`` if sample contains an attachment, ``false`` otherwise.
-    bool has_attachment() const { return ::z_sample_attachment(this->loan()) != nullptr; }
-
-    /// @brief Get the attachment of this sample. Will throw a ZException if ``Sample::has_attachment`` returns ``false``.
+    /// @brief Get the attachment of this sample.
     /// @return ``Bytes`` object representing sample attachment.
-    const Bytes& get_attachment() const {
+    std::optional<std::reference_wrapper<const Bytes>> get_attachment() const {
         auto attachment = ::z_sample_attachment(this->loan());
-        if (attachment == nullptr) {
-            throw ZException("Sample does not contain an attachment", Z_EINVAL);
-        }
-        return detail::as_owned_cpp_obj<Bytes>(attachment); 
+        if (attachment == nullptr) return {};
+        return std::cref(detail::as_owned_cpp_obj<Bytes>(attachment)); 
     }
 
     /// @brief Get the timestamp of this sample.

--- a/include/zenoh/api/session.hxx
+++ b/include/zenoh/api/session.hxx
@@ -166,6 +166,12 @@ class Session : public Owned<::z_owned_session_t> {
         QueryTarget target = QueryTarget::Z_QUERY_TARGET_ALL;
         /// @brief The replies consolidation strategy to apply on replies to the query.
         QueryConsolidation consolidation = QueryConsolidation();
+        /// @brief The priority of the get message.
+        Priority priority = Z_PRIORITY_DEFAULT;
+        /// @brief The congestion control to apply when routing get message.
+        CongestionControl congestion_control = Z_CONGESTION_CONTROL_DEFAULT;
+        /// @brief Whether Zenoh will NOT wait to batch get message with others to reduce the bandwith.
+        bool is_express = false;
         /// @brief An optional payload of the query.
         std::optional<Bytes> payload = {};
         /// @brief  An optional encoding of the query payload and/or attachment.
@@ -208,6 +214,9 @@ class Session : public Owned<::z_owned_session_t> {
         z_get_options_default(&opts);
         opts.target = options.target;
         opts.consolidation = static_cast<const z_query_consolidation_t&>(options.consolidation);
+        opts.congestion_control = options.congestion_control;
+        opts.priority = options.priority;
+        opts.is_express = options.is_express;
         opts.payload = detail::as_owned_c_ptr(options.payload);
         opts.encoding = detail::as_owned_c_ptr(options.encoding);
 #if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
@@ -505,6 +514,10 @@ class Session : public Owned<::z_owned_session_t> {
         /// @brief Allowed destination.
         Locality allowed_destination = ::zc_locality_default();
 #endif
+#if defined(ZENOHCXX_ZENOHC)
+        /// @brief Default encoding to use for Publisher::put.
+        std::optional<Encoding> encoding = {};
+#endif
 
         /// @name Methods
         /// @brief Create default option settings.
@@ -527,6 +540,9 @@ class Session : public Owned<::z_owned_session_t> {
         opts.is_express = options.is_express;
 #if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
         opts.allowed_destination = options.allowed_destination;
+#endif
+#if defined(ZENOHCXX_ZENOHC)
+        opts.encoding = detail::as_owned_c_ptr(options.encoding);
 #endif
 
         Publisher p(nullptr);

--- a/tests/universal/network/implicit.cxx
+++ b/tests/universal/network/implicit.cxx
@@ -25,8 +25,8 @@ void put_sub() {
     assert(alive);
     assert(msg.get_keyexpr() == "zenoh/test");
     assert(msg.get_payload().deserialize<std::string>() == "data");
-    assert(msg.has_attachment());
-    assert((msg.get_attachment().deserialize<std::vector<int32_t>>() == std::vector<int32_t>{-1, 10, 15000}));
+    assert(msg.get_attachment().has_value());
+    assert((msg.get_attachment()->get().deserialize<std::vector<int32_t>>() == std::vector<int32_t>{-1, 10, 15000}));
 }
 
 

--- a/tests/universal/network/queryable_get.cxx
+++ b/tests/universal/network/queryable_get.cxx
@@ -45,7 +45,7 @@ void queryable_get() {
         auto queryable = session1.declare_queryable(
             ke,
             [&queries](const Query& q) {
-                auto payload = q.get_payload().deserialize<int32_t>();
+                auto payload = q.get_payload()->get().deserialize<int32_t>();
                 queries.push_back(
                     QueryData{
                         .key = std::string(q.get_keyexpr().as_string_view()),
@@ -122,7 +122,7 @@ void queryable_get_channel() {
         assert(static_cast<bool>(query));
         assert(query.get_keyexpr() == selector);
         assert(query.get_parameters() == "ok");
-        assert(query.get_payload().deserialize<int32_t>() == 1);
+        assert(query.get_payload()->get().deserialize<int32_t>() == 1);
         query.reply(query.get_keyexpr(), Bytes::serialize(std::to_string(1)));
     }
 
@@ -141,7 +141,7 @@ void queryable_get_channel() {
         assert(static_cast<bool>(query));
         assert(query.get_keyexpr() == selector);
         assert(query.get_parameters() == "err");
-        assert(query.get_payload().deserialize<int32_t>() == 3);
+        assert(query.get_payload()->get().deserialize<int32_t>() == 3);
         query.reply_err(Bytes::serialize("err"));
     }
 


### PR DESCRIPTION
bump zenoh-c version;
add congestion_control, priority and is_express to GetOptions; 
add default encoding support in publisher options for ZENOH-C; 
add Encoding copy constructor and assignment;
add Config::from_env constructor;
add Encoding::set_schema for ZENOH-C;
fix examples to account for missing query payload;