### PR TITLE
Support for the QNX 7.1.0 qcc compiler

### DIFF
--- a/examples/universal/z_get.cxx
+++ b/examples/universal/z_get.cxx
@@ -86,7 +86,7 @@ int _main(int argc, char **argv) {
         done_signal.notify_all();
     };
 
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
     session.get(keyexpr, "", on_reply, on_done, {.target = Z_QUERY_TARGET_ALL, .payload = Bytes::serialize(value)});
 #else
     Session::GetOptions options;

--- a/examples/universal/z_get.cxx
+++ b/examples/universal/z_get.cxx
@@ -86,7 +86,7 @@ int _main(int argc, char **argv) {
         done_signal.notify_all();
     };
 
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
     session.get(keyexpr, "", on_reply, on_done, {.target = Z_QUERY_TARGET_ALL, .payload = Bytes::serialize(value)});
 #else
     Session::GetOptions options;

--- a/examples/universal/z_get.cxx
+++ b/examples/universal/z_get.cxx
@@ -86,7 +86,7 @@ int _main(int argc, char **argv) {
         done_signal.notify_all();
     };
 
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
     session.get(keyexpr, "", on_reply, on_done, {.target = Z_QUERY_TARGET_ALL, .payload = Bytes::serialize(value)});
 #else
     Session::GetOptions options;

--- a/examples/universal/z_get_attachment.cxx
+++ b/examples/universal/z_get_attachment.cxx
@@ -78,7 +78,7 @@ int _main(int argc, char **argv) {
 
     std::unordered_map<std::string, std::string> attachment = {{"Source", "C++"}};
 
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
     session.get(
         keyexpr, "", on_reply, on_done,
         {.target = Z_QUERY_TARGET_ALL, .payload = Bytes::serialize(value), .attachment = Bytes::serialize(attachment)});

--- a/examples/universal/z_get_attachment.cxx
+++ b/examples/universal/z_get_attachment.cxx
@@ -78,7 +78,7 @@ int _main(int argc, char **argv) {
 
     std::unordered_map<std::string, std::string> attachment = {{"Source", "C++"}};
 
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
     session.get(
         keyexpr, "", on_reply, on_done,
         {.target = Z_QUERY_TARGET_ALL, .payload = Bytes::serialize(value), .attachment = Bytes::serialize(attachment)});

--- a/examples/universal/z_get_attachment.cxx
+++ b/examples/universal/z_get_attachment.cxx
@@ -78,7 +78,7 @@ int _main(int argc, char **argv) {
 
     std::unordered_map<std::string, std::string> attachment = {{"Source", "C++"}};
 
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
     session.get(
         keyexpr, "", on_reply, on_done,
         {.target = Z_QUERY_TARGET_ALL, .payload = Bytes::serialize(value), .attachment = Bytes::serialize(attachment)});

--- a/examples/universal/z_get_channel.cxx
+++ b/examples/universal/z_get_channel.cxx
@@ -61,7 +61,7 @@ int _main(int argc, char **argv) {
     auto session = Session::open(std::move(config));
 
     std::cout << "Sending Query '" << expr << "'...\n";
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
     auto replies =
         session.get(keyexpr, "", channels::FifoChannel(16),
                     {.target = QueryTarget::Z_QUERY_TARGET_ALL, .payload = Bytes::serialize("Get from C++")});

--- a/examples/universal/z_get_channel.cxx
+++ b/examples/universal/z_get_channel.cxx
@@ -61,7 +61,7 @@ int _main(int argc, char **argv) {
     auto session = Session::open(std::move(config));
 
     std::cout << "Sending Query '" << expr << "'...\n";
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
     auto replies =
         session.get(keyexpr, "", channels::FifoChannel(16),
                     {.target = QueryTarget::Z_QUERY_TARGET_ALL, .payload = Bytes::serialize("Get from C++")});

--- a/examples/universal/z_get_channel.cxx
+++ b/examples/universal/z_get_channel.cxx
@@ -61,7 +61,7 @@ int _main(int argc, char **argv) {
     auto session = Session::open(std::move(config));
 
     std::cout << "Sending Query '" << expr << "'...\n";
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
     auto replies =
         session.get(keyexpr, "", channels::FifoChannel(16),
                     {.target = QueryTarget::Z_QUERY_TARGET_ALL, .payload = Bytes::serialize("Get from C++")});

--- a/examples/universal/z_get_channel_non_blocking.cxx
+++ b/examples/universal/z_get_channel_non_blocking.cxx
@@ -64,7 +64,7 @@ int _main(int argc, char **argv) {
 
     std::cout << "Sending Query '" << expr << "'...\n";
 
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
     auto replies =
         session.get(keyexpr, "", channels::FifoChannel(16),
                     {.target = QueryTarget::Z_QUERY_TARGET_ALL, .payload = Bytes::serialize("Get from C++")});

--- a/examples/universal/z_get_channel_non_blocking.cxx
+++ b/examples/universal/z_get_channel_non_blocking.cxx
@@ -64,7 +64,7 @@ int _main(int argc, char **argv) {
 
     std::cout << "Sending Query '" << expr << "'...\n";
 
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
     auto replies =
         session.get(keyexpr, "", channels::FifoChannel(16),
                     {.target = QueryTarget::Z_QUERY_TARGET_ALL, .payload = Bytes::serialize("Get from C++")});

--- a/examples/universal/z_get_channel_non_blocking.cxx
+++ b/examples/universal/z_get_channel_non_blocking.cxx
@@ -64,7 +64,7 @@ int _main(int argc, char **argv) {
 
     std::cout << "Sending Query '" << expr << "'...\n";
 
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
     auto replies =
         session.get(keyexpr, "", channels::FifoChannel(16),
                     {.target = QueryTarget::Z_QUERY_TARGET_ALL, .payload = Bytes::serialize("Get from C++")});

--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -88,7 +88,7 @@ int _main(int argc, char **argv) {
         ss << "[" << idx << "] " << value;
         auto s = ss.str();  // in C++20 use .view() instead
         std::cout << "Putting Data ('" << keyexpr << "': '" << s << "')...\n";
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
         pub.put(Bytes::serialize(s), {.encoding = Encoding("text/plain")});
 #else
         auto put_options = Publisher::PutOptions{};

--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -88,7 +88,7 @@ int _main(int argc, char **argv) {
         ss << "[" << idx << "] " << value;
         auto s = ss.str();  // in C++20 use .view() instead
         std::cout << "Putting Data ('" << keyexpr << "': '" << s << "')...\n";
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
         pub.put(Bytes::serialize(s), {.encoding = Encoding("text/plain")});
 #else
         auto put_options = Publisher::PutOptions{};

--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -88,7 +88,7 @@ int _main(int argc, char **argv) {
         ss << "[" << idx << "] " << value;
         auto s = ss.str();  // in C++20 use .view() instead
         std::cout << "Putting Data ('" << keyexpr << "': '" << s << "')...\n";
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
         pub.put(Bytes::serialize(s), {.encoding = Encoding("text/plain")});
 #else
         auto put_options = Publisher::PutOptions{};

--- a/examples/universal/z_pub_attachment.cxx
+++ b/examples/universal/z_pub_attachment.cxx
@@ -75,7 +75,7 @@ int _main(int argc, char **argv) {
         std::cout << "Putting Data ('" << keyexpr << "': '" << s << "')...\n";
         // add some other attachment value
         attachment_map["index"] = std::to_string(idx);
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
         pub.put(Bytes::serialize(s),
                 {.encoding = Encoding("text/plain"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/examples/universal/z_pub_attachment.cxx
+++ b/examples/universal/z_pub_attachment.cxx
@@ -75,7 +75,7 @@ int _main(int argc, char **argv) {
         std::cout << "Putting Data ('" << keyexpr << "': '" << s << "')...\n";
         // add some other attachment value
         attachment_map["index"] = std::to_string(idx);
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
         pub.put(Bytes::serialize(s),
                 {.encoding = Encoding("text/plain"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/examples/universal/z_pub_attachment.cxx
+++ b/examples/universal/z_pub_attachment.cxx
@@ -75,7 +75,7 @@ int _main(int argc, char **argv) {
         std::cout << "Putting Data ('" << keyexpr << "': '" << s << "')...\n";
         // add some other attachment value
         attachment_map["index"] = std::to_string(idx);
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
         pub.put(Bytes::serialize(s),
                 {.encoding = Encoding("text/plain"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/examples/universal/z_pub_thr.cxx
+++ b/examples/universal/z_pub_thr.cxx
@@ -67,7 +67,7 @@ int _main(int argc, char **argv) {
     auto session = Session::open(std::move(config));
 
     std::cout << "Declaring Publisher on " << keyexpr << "...\n";
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
     auto pub = session.declare_publisher(KeyExpr(keyexpr), {.congestion_control = Z_CONGESTION_CONTROL_BLOCK});
 #else
     auto pub_options = Session::PublisherOptions::create_default();

--- a/examples/universal/z_pub_thr.cxx
+++ b/examples/universal/z_pub_thr.cxx
@@ -67,7 +67,7 @@ int _main(int argc, char **argv) {
     auto session = Session::open(std::move(config));
 
     std::cout << "Declaring Publisher on " << keyexpr << "...\n";
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
     auto pub = session.declare_publisher(KeyExpr(keyexpr), {.congestion_control = Z_CONGESTION_CONTROL_BLOCK});
 #else
     auto pub_options = Session::PublisherOptions::create_default();

--- a/examples/universal/z_pub_thr.cxx
+++ b/examples/universal/z_pub_thr.cxx
@@ -67,7 +67,7 @@ int _main(int argc, char **argv) {
     auto session = Session::open(std::move(config));
 
     std::cout << "Declaring Publisher on " << keyexpr << "...\n";
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
     auto pub = session.declare_publisher(KeyExpr(keyexpr), {.congestion_control = Z_CONGESTION_CONTROL_BLOCK});
 #else
     auto pub_options = Session::PublisherOptions::create_default();

--- a/examples/universal/z_put.cxx
+++ b/examples/universal/z_put.cxx
@@ -73,7 +73,7 @@ int _main(int argc, char **argv) {
 
     std::unordered_map<std::string, std::string> attachment_map = {{"serial_number", "123"},
                                                                    {"coordinates", "48.7082,2.1498"}};
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
     session.put(KeyExpr(keyexpr), Bytes::serialize(value),
                 {.encoding = Encoding("text/plain"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/examples/universal/z_put.cxx
+++ b/examples/universal/z_put.cxx
@@ -73,7 +73,7 @@ int _main(int argc, char **argv) {
 
     std::unordered_map<std::string, std::string> attachment_map = {{"serial_number", "123"},
                                                                    {"coordinates", "48.7082,2.1498"}};
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
     session.put(KeyExpr(keyexpr), Bytes::serialize(value),
                 {.encoding = Encoding("text/plain"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/examples/universal/z_put.cxx
+++ b/examples/universal/z_put.cxx
@@ -73,7 +73,7 @@ int _main(int argc, char **argv) {
 
     std::unordered_map<std::string, std::string> attachment_map = {{"serial_number", "123"},
                                                                    {"coordinates", "48.7082,2.1498"}};
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
     session.put(KeyExpr(keyexpr), Bytes::serialize(value),
                 {.encoding = Encoding("text/plain"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -83,7 +83,7 @@ int _main(int argc, char **argv) {
             std::cout << "' value = '" << payload->get().deserialize<std::string>();
         }
         std::cout << "'\n";
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
         query.reply(KeyExpr(expr), Bytes::serialize(value), {.encoding = Encoding("text/plain")});
 #else
         Query::ReplyOptions reply_options;

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -83,7 +83,7 @@ int _main(int argc, char **argv) {
             std::cout << "' value = '" << payload->get().deserialize<std::string>();
         }
         std::cout << "'\n";
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
         query.reply(KeyExpr(expr), Bytes::serialize(value), {.encoding = Encoding("text/plain")});
 #else
         Query::ReplyOptions reply_options;

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -83,7 +83,7 @@ int _main(int argc, char **argv) {
             std::cout << "' value = '" << payload->get().deserialize<std::string>();
         }
         std::cout << "'\n";
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
         query.reply(KeyExpr(expr), Bytes::serialize(value), {.encoding = Encoding("text/plain")});
 #else
         Query::ReplyOptions reply_options;

--- a/examples/universal/z_queryable_attachment.cxx
+++ b/examples/universal/z_queryable_attachment.cxx
@@ -76,7 +76,7 @@ int _main(int argc, char **argv) {
                 std::cout << "   attachment: " << key << ": '" << value << "'\n";
             }
         }
-#if __cpp_designated_initializers >= 201707L
+#if __cplusplus > 201703L
         query.reply(KeyExpr(expr), Bytes::serialize(value),
                     {.encoding = Encoding("text/palin"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/examples/universal/z_queryable_attachment.cxx
+++ b/examples/universal/z_queryable_attachment.cxx
@@ -76,7 +76,7 @@ int _main(int argc, char **argv) {
                 std::cout << "   attachment: " << key << ": '" << value << "'\n";
             }
         }
-#if __cplusplus > 201703L
+#if __cpp_designated_initializers >= 201707L
         query.reply(KeyExpr(expr), Bytes::serialize(value),
                     {.encoding = Encoding("text/palin"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/examples/universal/z_queryable_attachment.cxx
+++ b/examples/universal/z_queryable_attachment.cxx
@@ -76,7 +76,7 @@ int _main(int argc, char **argv) {
                 std::cout << "   attachment: " << key << ": '" << value << "'\n";
             }
         }
-#if __cplusplus >= 201703L
+#if __cpp_designated_initializers >= 201707L
         query.reply(KeyExpr(expr), Bytes::serialize(value),
                     {.encoding = Encoding("text/palin"), .attachment = Bytes::serialize(attachment_map)});
 #else

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -428,18 +428,18 @@ struct ZenohDeserializer<std::map<K, V, C, Allocator>> {
         }                                                                                                \
     };
 
-__ZENOH_DESERIALIZE_ARITHMETIC(uint8_t, uint8);
-__ZENOH_DESERIALIZE_ARITHMETIC(uint16_t, uint16);
-__ZENOH_DESERIALIZE_ARITHMETIC(uint32_t, uint32);
-__ZENOH_DESERIALIZE_ARITHMETIC(uint64_t, uint64);
+__ZENOH_DESERIALIZE_ARITHMETIC(uint8_t, uint8)
+__ZENOH_DESERIALIZE_ARITHMETIC(uint16_t, uint16)
+__ZENOH_DESERIALIZE_ARITHMETIC(uint32_t, uint32)
+__ZENOH_DESERIALIZE_ARITHMETIC(uint64_t, uint64)
 
-__ZENOH_DESERIALIZE_ARITHMETIC(int8_t, int8);
-__ZENOH_DESERIALIZE_ARITHMETIC(int16_t, int16);
-__ZENOH_DESERIALIZE_ARITHMETIC(int32_t, int32);
-__ZENOH_DESERIALIZE_ARITHMETIC(int64_t, int64);
+__ZENOH_DESERIALIZE_ARITHMETIC(int8_t, int8)
+__ZENOH_DESERIALIZE_ARITHMETIC(int16_t, int16)
+__ZENOH_DESERIALIZE_ARITHMETIC(int32_t, int32)
+__ZENOH_DESERIALIZE_ARITHMETIC(int64_t, int64)
 
-__ZENOH_DESERIALIZE_ARITHMETIC(float, float);
-__ZENOH_DESERIALIZE_ARITHMETIC(double, double);
+__ZENOH_DESERIALIZE_ARITHMETIC(float, float)
+__ZENOH_DESERIALIZE_ARITHMETIC(double, double)
 
 #undef __ZENOH_DESERIALIZE_ARITHMETIC
 }  // namespace detail
@@ -449,7 +449,7 @@ struct Slice {
     size_t len;
 };
 
-inline auto make_slice(const uint8_t* data, size_t len) { return Slice{data, len}; };
+inline auto make_slice(const uint8_t* data, size_t len) { return Slice{data, len}; }
 
 template <class Deleter>
 struct OwnedSlice {
@@ -461,7 +461,7 @@ struct OwnedSlice {
 template <class Deleter>
 auto make_owned_slice(uint8_t* data, size_t len, Deleter&& d) {
     return OwnedSlice<std::remove_reference_t<Deleter>>{data, len, std::forward<Deleter>(d)};
-};
+}
 
 /// @brief Default codec for Zenoh serialization / deserialziation
 class ZenohCodec {

--- a/include/zenoh/api/closures.hxx
+++ b/include/zenoh/api/closures.hxx
@@ -14,7 +14,7 @@
 #pragma once
 namespace zenoh::closures {
 namespace detail {
-inline void none(){};
+inline void none(){}
 }
 static auto none = &detail::none;
 using None = decltype(none);

--- a/include/zenoh/api/closures.hxx
+++ b/include/zenoh/api/closures.hxx
@@ -14,8 +14,8 @@
 #pragma once
 namespace zenoh::closures {
 namespace detail {
-inline void none(){}
-}
+inline void none() {}
+}  // namespace detail
 static auto none = &detail::none;
 using None = decltype(none);
 }  // namespace zenoh::closures


### PR DESCRIPTION
* Removed extraneous semicolons to solve q++ compilation errors.
* Changed test for C++ designated initializers to check for language feature support rather than C++ version to solve q++ compilation errors.

Closes #195.