### PR TITLE
Align renamed API calls

### DIFF
--- a/examples/universal/z_delete.cxx
+++ b/examples/universal/z_delete.cxx
@@ -48,7 +48,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_get.cxx
+++ b/examples/universal/z_get.cxx
@@ -46,7 +46,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_get_channel.cxx
+++ b/examples/universal/z_get_channel.cxx
@@ -42,7 +42,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_get_channel_non_blocking.cxx
+++ b/examples/universal/z_get_channel_non_blocking.cxx
@@ -45,7 +45,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_info.cxx
+++ b/examples/universal/z_info.cxx
@@ -39,7 +39,7 @@ int _main(int argc, char** argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_pub.cxx
+++ b/examples/universal/z_pub.cxx
@@ -60,7 +60,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_pub_delete.cxx
+++ b/examples/universal/z_pub_delete.cxx
@@ -49,7 +49,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_pub_thr.cxx
+++ b/examples/universal/z_pub_thr.cxx
@@ -46,7 +46,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_put.cxx
+++ b/examples/universal/z_put.cxx
@@ -52,7 +52,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -54,7 +54,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_scout.cxx
+++ b/examples/universal/z_scout.cxx
@@ -66,7 +66,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_sub.cxx
+++ b/examples/universal/z_sub.cxx
@@ -63,7 +63,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/universal/z_sub_thr.cxx
+++ b/examples/universal/z_sub_thr.cxx
@@ -87,7 +87,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/zenohc/z_get_liveliness.cxx
+++ b/examples/zenohc/z_get_liveliness.cxx
@@ -43,7 +43,7 @@ int _main(int argc, char **argv) {
     if (locator) {
 #ifdef ZENOHCXX_ZENOHC
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 #elif ZENOHCXX_ZENOHPICO
         config.insert(Z_CONFIG_CONNECT_KEY, locator, &err);
 #else

--- a/examples/zenohc/z_get_shm.cxx
+++ b/examples/zenohc/z_get_shm.cxx
@@ -39,7 +39,7 @@ int _main(int argc, char **argv) {
     ZResult err;
     if (locator) {
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 
         if (err != Z_OK) {
             std::cout << "Invalid locator: " << locator << std::endl;

--- a/examples/zenohc/z_liveliness.cxx
+++ b/examples/zenohc/z_liveliness.cxx
@@ -43,7 +43,7 @@ int _main(int argc, char **argv) {
     ZResult err;
     if (locator) {
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 
         if (err != Z_OK) {
             std::cout << "Invalid locator: " << locator << std::endl;

--- a/examples/zenohc/z_pub_shm.cxx
+++ b/examples/zenohc/z_pub_shm.cxx
@@ -46,7 +46,7 @@ int _main(int argc, char **argv) {
     ZResult err;
     if (locator) {
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 
         if (err != Z_OK) {
             std::cout << "Invalid locator: " << locator << std::endl;

--- a/examples/zenohc/z_pub_shm_thr.cxx
+++ b/examples/zenohc/z_pub_shm_thr.cxx
@@ -38,7 +38,7 @@ int _main(int argc, char **argv) {
     ZResult err;
     if (locator) {
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 
         if (err != Z_OK) {
             std::cout << "Invalid locator: " << locator << std::endl;

--- a/examples/zenohc/z_queryable_shm.cxx
+++ b/examples/zenohc/z_queryable_shm.cxx
@@ -41,7 +41,7 @@ int _main(int argc, char **argv) {
     ZResult err;
     if (locator) {
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 
         if (err != Z_OK) {
             std::cout << "Invalid locator: " << locator << std::endl;

--- a/examples/zenohc/z_sub_liveliness.cxx
+++ b/examples/zenohc/z_sub_liveliness.cxx
@@ -48,7 +48,7 @@ int _main(int argc, char **argv) {
     ZResult err;
     if (locator) {
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 
         if (err != Z_OK) {
             std::cout << "Invalid locator: " << locator << std::endl;

--- a/examples/zenohc/z_sub_shm.cxx
+++ b/examples/zenohc/z_sub_shm.cxx
@@ -79,7 +79,7 @@ int _main(int argc, char **argv) {
     ZResult err;
     if (locator) {
         auto locator_json_str_list = std::string("[\"") + locator + "\"]";
-        config.insert_json(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
+        config.insert_json5(Z_CONFIG_CONNECT_KEY, locator_json_str_list.c_str(), &err);
 
         if (err != Z_OK) {
             std::cout << "Invalid locator: " << locator << std::endl;

--- a/include/zenoh/api/config.hxx
+++ b/include/zenoh/api/config.hxx
@@ -110,7 +110,7 @@ class Config : public Owned<::z_owned_config_t> {
     /// thrown in case of error.
     /// @return true if the parameter was inserted, false otherwise.
     /// @note zenoh-c only.
-    void insert_json(const std::string& key, const std::string& value, ZResult* err = nullptr) {
+    void insert_json5(const std::string& key, const std::string& value, ZResult* err = nullptr) {
         __ZENOH_RESULT_CHECK(::zc_config_insert_json5(interop::as_loaned_c_ptr(*this), key.c_str(), value.c_str()), err,
                              std::string("Failed to insert '")
                                  .append(value)

--- a/include/zenoh/api/config.hxx
+++ b/include/zenoh/api/config.hxx
@@ -111,7 +111,7 @@ class Config : public Owned<::z_owned_config_t> {
     /// @return true if the parameter was inserted, false otherwise.
     /// @note zenoh-c only.
     void insert_json(const std::string& key, const std::string& value, ZResult* err = nullptr) {
-        __ZENOH_RESULT_CHECK(::zc_config_insert_json(interop::as_loaned_c_ptr(*this), key.c_str(), value.c_str()), err,
+        __ZENOH_RESULT_CHECK(::zc_config_insert_json5(interop::as_loaned_c_ptr(*this), key.c_str(), value.c_str()), err,
                              std::string("Failed to insert '")
                                  .append(value)
                                  .append("' for the key '")

--- a/include/zenoh/api/hello.hxx
+++ b/include/zenoh/api/hello.hxx
@@ -50,7 +50,7 @@ class Hello : public Owned<::z_owned_hello_t> {
         ::z_hello_locators(interop::as_loaned_c_ptr(*this), &out);
         auto out_loaned = ::z_loan(out);
 #else
-        auto out_loaned = ::z_hello_locators(interop::as_loaned_c_ptr(*this));
+        auto out_loaned = ::zp_hello_locators(interop::as_loaned_c_ptr(*this));
 #endif
         std::vector<std::string_view> locators(::z_string_array_len(out_loaned));
         for (size_t i = 0; i < ::z_string_array_len(out_loaned); i++) {

--- a/tests/zenohc/config.cxx
+++ b/tests/zenohc/config.cxx
@@ -22,8 +22,8 @@ using namespace zenoh;
 void test_config_insert() {
     std::vector<std::string> peers = {"tcp/192.168.0.1", "tcp/10.0.0.1"};
     auto config = Config::create_default();
-    config.insert_json("mode", "\"client\"");
-    config.insert_json("connect/endpoints", "[\"tcp/192.168.0.1\", \"tcp/10.0.0.1\"]");
+    config.insert_json5("mode", "\"client\"");
+    config.insert_json5("connect/endpoints", "[\"tcp/192.168.0.1\", \"tcp/10.0.0.1\"]");
     assert(config.get("mode") == "\"client\"");
     assert(config.get("connect/endpoints") == "[\"tcp/192.168.0.1\",\"tcp/10.0.0.1\"]");
 }


### PR DESCRIPTION
- Rename z_hello_locators to zp_hello_locators (https://github.com/eclipse-zenoh/zenoh-pico/pull/677)
- Rename zc_config_insert_json to zc_config_insert_json5 (https://github.com/eclipse-zenoh/zenoh-c/pull/698)

Closes: https://github.com/eclipse-zenoh/zenoh-c/issues/693