### PR TITLE
prepend feature macros with Z_FEATURE to avoid name collisions

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2353,7 +2353,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = ZENOHCXX_ZENOHPICO ZENOHCXX_ZENOHC SHARED_MEMORY UNSTABLE __DOXYGEN__
+PREDEFINED             = ZENOHCXX_ZENOHPICO ZENOHCXX_ZENOHC Z_FEATURE_SHARED_MEMORY Z_FEATURE_UNSTABLE_API __DOXYGEN__
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/examples/universal/z_info.cxx
+++ b/examples/universal/z_info.cxx
@@ -55,7 +55,7 @@ int _main(int argc, char** argv) {
     std::cout << "Opening session...\n";
     auto session = Session::open(std::move(config));
 
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
     std::cout << "own id: " << session.get_zid() << std::endl;
 
     std::cout << "routers ids:\n";

--- a/examples/universal/z_scout.cxx
+++ b/examples/universal/z_scout.cxx
@@ -35,7 +35,7 @@ void printlocators(const std::vector<std::string_view> &locs) {
 
 void printhello(const Hello &hello) {
     std::cout << "Hello { ";
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
     std::cout << "pid: " << hello.get_id() << ", ";
 #endif
     std::cout << "whatami: " << hello.get_whatami();

--- a/examples/zenohc/z_sub_shm.cxx
+++ b/examples/zenohc/z_sub_shm.cxx
@@ -36,18 +36,18 @@ const char *kind_to_str(SampleKind kind) {
 
 void data_handler(const Sample &sample) {
 // if Zenoh is built without SHM support, the only buffer type it can receive is RAW
-#if !defined(SHARED_MEMORY)
+#if !defined(Z_FEATURE_SHARED_MEMORY)
     const char *payload_type = "RAW";
 #endif
 
 // if Zenoh is built with SHM support but without SHM API (that is unstable), it can
 // receive buffers of any type, but there is no way to detect the buffer type
-#if defined(SHARED_MEMORY) && !defined(UNSTABLE)
+#if defined(Z_FEATURE_SHARED_MEMORY) && !defined(Z_FEATURE_UNSTABLE_API)
     const char *payload_type = "UNKNOWN";
 #endif
 
 // if Zenoh is built with SHM support and with SHM API, we can detect the exact buffer type
-#if defined(SHARED_MEMORY) && defined(UNSTABLE)
+#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
     const char *payload_type = "RAW";
     {
         ZResult result;

--- a/include/zenoh/api.hxx
+++ b/include/zenoh/api.hxx
@@ -19,7 +19,7 @@
 #include "api/encoding.hxx"
 #include "api/enums.hxx"
 #include "api/hello.hxx"
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
 #include "api/id.hxx"
 #endif
 #include "api/channels.hxx"
@@ -35,6 +35,6 @@
 #include "api/session.hxx"
 #include "api/subscriber.hxx"
 #include "api/timestamp.hxx"
-#if defined SHARED_MEMORY && defined UNSTABLE
+#if defined Z_FEATURE_SHARED_MEMORY && defined Z_FEATURE_UNSTABLE_API
 #include "api/shm/shm.hxx"
 #endif

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -18,7 +18,7 @@
 #include "base.hxx"
 #include "closures.hxx"
 #include "interop.hxx"
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 #include "shm/buffer/buffer.hxx"
 #endif
 
@@ -357,7 +357,7 @@ struct ZenohDeserializer<std::string> {
     }
 };
 
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 template <>
 struct ZenohDeserializer<ZShm> {
     static ZShm deserialize(const Bytes& b, ZResult* err = nullptr) {
@@ -553,7 +553,7 @@ class ZenohCodec {
 
     Bytes serialize(const Bytes& b) const { return b.clone(); }
 
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
     Bytes serialize(ZShm&& shm, ZResult* err = nullptr) const {
         Bytes b;
         __ZENOH_RESULT_CHECK(::z_bytes_serialize_from_shm(interop::as_owned_c_ptr(b), interop::as_moved_c_ptr(shm)),

--- a/include/zenoh/api/enums.hxx
+++ b/include/zenoh/api/enums.hxx
@@ -42,7 +42,7 @@ typedef ::z_sample_kind_t SampleKind;
 ///           It optimizes bandwidth.
 typedef ::z_consolidation_mode_t ConsolidationMode;
 
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Publisher reliability values.
 ///
@@ -101,7 +101,7 @@ inline std::string_view whatami_as_str(WhatAmI whatami) {
     return std::string_view(::z_string_data(::z_loan(str_out)), ::z_string_len(::z_loan(str_out)));
 }
 
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief The locality of samples to be received by subscribers or targeted by publishers.
 ///

--- a/include/zenoh/api/hello.hxx
+++ b/include/zenoh/api/hello.hxx
@@ -16,7 +16,7 @@
 #include "base.hxx"
 #include "enums.hxx"
 #include "interop.hxx"
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
 #include "id.hxx"
 #endif
 
@@ -30,7 +30,7 @@ class Hello : public Owned<::z_owned_hello_t> {
    public:
     /// @name Methods
 
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Get ``Id`` of the entity.

--- a/include/zenoh/api/keyexpr.hxx
+++ b/include/zenoh/api/keyexpr.hxx
@@ -119,7 +119,7 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     bool intersects(const KeyExpr& other) const {
         return ::z_keyexpr_intersects(interop::as_loaned_c_ptr(*this), interop::as_loaned_c_ptr(other));
     }
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Intersection level of 2 key expressions.

--- a/include/zenoh/api/publisher.hxx
+++ b/include/zenoh/api/publisher.hxx
@@ -20,7 +20,7 @@
 #include "interop.hxx"
 #include "keyexpr.hxx"
 #include "timestamp.hxx"
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
 #include "source_info.hxx"
 #endif
 #include <optional>
@@ -43,7 +43,7 @@ class Publisher : public Owned<::z_owned_publisher_t> {
         std::optional<Encoding> encoding = {};
         /// @brief the timestamp of this message.
         std::optional<Timestamp> timestamp = {};
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief The source info of this message.
@@ -79,7 +79,7 @@ class Publisher : public Owned<::z_owned_publisher_t> {
         ::z_publisher_put_options_t opts;
         z_publisher_put_options_default(&opts);
         opts.encoding = interop::as_moved_c_ptr(options.encoding);
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         opts.source_info = interop::as_moved_c_ptr(options.source_info);
 #endif
         opts.attachment = interop::as_moved_c_ptr(options.attachment);
@@ -105,7 +105,7 @@ class Publisher : public Owned<::z_owned_publisher_t> {
     const KeyExpr& get_keyexpr() const {
         return interop::as_owned_cpp_ref<KeyExpr>(::z_publisher_keyexpr(interop::as_loaned_c_ptr(*this)));
     }
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Get the id of the publisher.

--- a/include/zenoh/api/query.hxx
+++ b/include/zenoh/api/query.hxx
@@ -23,7 +23,7 @@
 #include "enums.hxx"
 #include "interop.hxx"
 #include "keyexpr.hxx"
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
 #include "source_info.hxx"
 #endif
 #include "timestamp.hxx"
@@ -93,7 +93,7 @@ class Query : public Owned<::z_owned_query_t> {
         bool is_express = false;
         /// @brief The timestamp of this message.
         std::optional<Timestamp> timestamp = {};
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief The source info of this reply message.
@@ -122,7 +122,7 @@ class Query : public Owned<::z_owned_query_t> {
         opts.congestion_control = options.congestion_control;
         opts.is_express = options.is_express;
         opts.timestamp = interop::as_copyable_c_ptr(options.timestamp);
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         opts.source_info = interop::as_moved_c_ptr(options.source_info);
 #endif
         opts.attachment = interop::as_moved_c_ptr(options.attachment);
@@ -172,7 +172,7 @@ class Query : public Owned<::z_owned_query_t> {
         bool is_express = false;
         /// @brief the timestamp of this message.
         std::optional<Timestamp> timestamp = {};
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief The source info of this reply message.
@@ -200,7 +200,7 @@ class Query : public Owned<::z_owned_query_t> {
         opts.congestion_control = options.congestion_control;
         opts.is_express = options.is_express;
         opts.timestamp = interop::as_copyable_c_ptr(options.timestamp);
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         opts.source_info = interop::as_moved_c_ptr(options.source_info);
 #endif
         opts.attachment = interop::as_moved_c_ptr(options.attachment);

--- a/include/zenoh/api/reply.hxx
+++ b/include/zenoh/api/reply.hxx
@@ -17,7 +17,7 @@
 #include "bytes.hxx"
 #include "interop.hxx"
 #include "sample.hxx"
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
 #include "id.hxx"
 #endif
 
@@ -71,7 +71,7 @@ class Reply : public Owned<::z_owned_reply_t> {
         return interop::as_owned_cpp_ref<ReplyError>(::z_reply_err(interop::as_loaned_c_ptr(*this)));
     }
 
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Get the id of the Zenoh instance that issued this reply.

--- a/include/zenoh/api/sample.hxx
+++ b/include/zenoh/api/sample.hxx
@@ -22,7 +22,7 @@
 #include "interop.hxx"
 #include "keyexpr.hxx"
 #include "timestamp.hxx"
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
 #include "source_info.hxx"
 #endif
 
@@ -90,7 +90,7 @@ class Sample : public Owned<::z_owned_sample_t> {
     /// @brief Get the express setting this sample was sent with.
     /// @return ``CongestionControl`` value.
     bool get_express() const { return ::z_sample_express(interop::as_loaned_c_ptr(*this)); }
-#if defined(ZENOHCXX) && defined(UNSTABLE)
+#if defined(ZENOHCXX) && defined(Z_FEATURE_UNSTABLE_API)
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Get the source info of this sample.
@@ -99,7 +99,7 @@ class Sample : public Owned<::z_owned_sample_t> {
     }
 #endif
 
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Get the reliability this sample was sent with.

--- a/include/zenoh/api/session.hxx
+++ b/include/zenoh/api/session.hxx
@@ -23,16 +23,16 @@
 #include "enums.hxx"
 #include "interop.hxx"
 #include "timestamp.hxx"
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
 #include "id.hxx"
 #endif
 #include "publisher.hxx"
 #include "query_consolidation.hxx"
 #include "subscriber.hxx"
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
 #include "liveliness.hxx"
 #endif
-#if defined(ZENOHCXX_ZENOHC) && defined(SHARED_MEMORY) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
 #include "shm/client_storage/client_storage.hxx"
 #endif
 
@@ -91,7 +91,7 @@ class Session : public Owned<::z_owned_session_t> {
 #endif
     }
 
-#if defined(ZENOHCXX_ZENOHC) && defined(SHARED_MEMORY) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
     /// @brief Create a new Session with custom SHM client set.
     /// @param config Zenoh session ``Config``.
     /// @param shm_storage Storage with custom SHM clients.
@@ -119,7 +119,7 @@ class Session : public Owned<::z_owned_session_t> {
         return Session(std::move(config), std::move(options), err);
     }
 
-#if defined(ZENOHCXX_ZENOHC) && defined(SHARED_MEMORY) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
     /// @brief A factory method equivalent to a ``Session`` constructor for custom SHM clients list.
     /// @param config Zenoh session ``Config``.
     /// @param shm_storage Storage with custom SHM clients.
@@ -134,7 +134,7 @@ class Session : public Owned<::z_owned_session_t> {
 #endif
 
     /// @name Methods
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Get the unique identifier of the zenoh node associated to this ``Session``.
@@ -183,7 +183,7 @@ class Session : public Owned<::z_owned_session_t> {
         std::optional<Bytes> payload = {};
         /// @brief  An optional encoding of the query payload and/or attachment.
         std::optional<Encoding> encoding = {};
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief The source info for the query.
@@ -229,7 +229,7 @@ class Session : public Owned<::z_owned_session_t> {
         opts.is_express = options.is_express;
         opts.payload = interop::as_moved_c_ptr(options.payload);
         opts.encoding = interop::as_moved_c_ptr(options.encoding);
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         opts.source_info = interop::as_moved_c_ptr(options.source_info);
 #endif
         opts.attachment = interop::as_moved_c_ptr(options.attachment);
@@ -262,7 +262,7 @@ class Session : public Owned<::z_owned_session_t> {
         opts.consolidation = *interop::as_copyable_c_ptr(options.consolidation);
         opts.payload = interop::as_moved_c_ptr(options.payload);
         opts.encoding = interop::as_moved_c_ptr(options.encoding);
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         opts.source_info = interop::as_moved_c_ptr(options.source_info);
 #endif
         opts.attachment = interop::as_moved_c_ptr(options.attachment);
@@ -284,7 +284,7 @@ class Session : public Owned<::z_owned_session_t> {
         CongestionControl congestion_control = Z_CONGESTION_CONTROL_DEFAULT;
         /// @brief Whether Zenoh will NOT wait to batch delete message with others to reduce the bandwith.
         bool is_express = false;
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief The delete operation reliability.
@@ -310,7 +310,7 @@ class Session : public Owned<::z_owned_session_t> {
         opts.congestion_control = options.congestion_control;
         opts.priority = options.priority;
         opts.is_express = options.is_express;
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
         opts.reliability = options.reliability;
 #endif
 
@@ -328,7 +328,7 @@ class Session : public Owned<::z_owned_session_t> {
         CongestionControl congestion_control = Z_CONGESTION_CONTROL_DEFAULT;
         /// @brief Whether Zenoh will NOT wait to batch this message with others to reduce the bandwith.
         bool is_express = false;
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief Allowed destination.
@@ -338,13 +338,13 @@ class Session : public Owned<::z_owned_session_t> {
         std::optional<Timestamp> timestamp = {};
         /// @brief  An optional encoding of the message payload and/or attachment.
         std::optional<Encoding> encoding = {};
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief The put operation reliability.
         Reliability reliability = Reliability::Z_RELIABILITY_BEST_EFFORT;
 #endif
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief The source info of this message.
@@ -372,10 +372,10 @@ class Session : public Owned<::z_owned_session_t> {
         opts.congestion_control = options.congestion_control;
         opts.priority = options.priority;
         opts.is_express = options.is_express;
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
         opts.reliability = options.reliability;
 #endif
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         opts.allowed_destination = options.allowed_destination;
         opts.source_info = interop::as_moved_c_ptr(options.source_info);
 #endif
@@ -542,13 +542,13 @@ class Session : public Owned<::z_owned_session_t> {
         Priority priority = Z_PRIORITY_DEFAULT;
         /// @brief If true, Zenoh will not wait to batch this message with others to reduce the bandwith.
         bool is_express = false;
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief The publisher reliability.
         Reliability reliability = Reliability::Z_RELIABILITY_BEST_EFFORT;
 #endif
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
         /// release.
         /// @brief Allowed destination.
@@ -576,10 +576,10 @@ class Session : public Owned<::z_owned_session_t> {
         opts.congestion_control = options.congestion_control;
         opts.priority = options.priority;
         opts.is_express = options.is_express;
-#if defined(UNSTABLE)
+#if defined(Z_FEATURE_UNSTABLE_API)
         opts.reliability = options.reliability;
 #endif
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
         opts.allowed_destination = options.allowed_destination;
 #endif
         opts.encoding = interop::as_moved_c_ptr(options.encoding);
@@ -591,7 +591,7 @@ class Session : public Owned<::z_owned_session_t> {
         return p;
     }
 
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Fetches the Zenoh IDs of all connected routers.
@@ -693,7 +693,7 @@ class Session : public Owned<::z_owned_session_t> {
     }
 #endif
 
-#if defined(ZENOHCXX_ZENOHC) && defined(UNSTABLE)
+#if defined(ZENOHCXX_ZENOHC) && defined(Z_FEATURE_UNSTABLE_API)
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Options to pass to ``Session::liveliness_declare_token``.

--- a/include/zenoh/api/source_info.hxx
+++ b/include/zenoh/api/source_info.hxx
@@ -16,7 +16,7 @@
 #include "../zenohc.hxx"
 #include "base.hxx"
 #include "interop.hxx"
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
 #include "id.hxx"
 #endif
 

--- a/include/zenoh/api/timestamp.hxx
+++ b/include/zenoh/api/timestamp.hxx
@@ -15,7 +15,7 @@
 #include "../zenohc.hxx"
 #include "base.hxx"
 #include "interop.hxx"
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
 #include "id.hxx"
 #endif
 
@@ -32,7 +32,7 @@ class Timestamp : public Copyable<::z_timestamp_t> {
     /// @return time in NTP64 format.
     uint64_t get_time() const { return ::z_timestamp_ntp64_time(&this->inner()); }
 
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
     /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future
     /// release.
     /// @brief Get the unique id of the timestamp.

--- a/include/zenoh/detail/closures_concrete.hxx
+++ b/include/zenoh/detail/closures_concrete.hxx
@@ -19,7 +19,7 @@
 #include "../api/sample.hxx"
 #include "../zenohc.hxx"
 #include "closures.hxx"
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
 #include "../api/id.hxx"
 #endif
 #include "../api/hello.hxx"
@@ -41,7 +41,7 @@ inline void _zenoh_on_query_call(::z_loaned_query_t* query, void* context) {
     IClosure<void, Query&>::call_from_context(context, interop::as_owned_cpp_ref<Query>(query));
 }
 
-#if defined UNSTABLE
+#if defined Z_FEATURE_UNSTABLE_API
 inline void _zenoh_on_id_call(const ::z_id_t* z_id, void* context) {
     IClosure<void, const Id&>::call_from_context(context, interop::as_copyable_cpp_ref<Id>(z_id));
 }

--- a/include/zenoh/zenohc.hxx
+++ b/include/zenoh/zenohc.hxx
@@ -10,9 +10,6 @@
 #if defined(ZENOHCXX_ZENOHPICO)
 #include "zenoh-pico.h"
 // use same macro to check for unstable features
-#if Z_FEATURE_UNSTABLE_API == 1
-#define UNSTABLE
-#endif
 #elif defined(ZENOHCXX_ZENOHC)
 #include "zenoh.h"
 #endif

--- a/tests/universal/network/pub_sub.cxx
+++ b/tests/universal/network/pub_sub.cxx
@@ -26,7 +26,7 @@ struct CommonAllocator {
     Bytes alloc_with_data(const char data[]) { return Bytes::serialize(data); }
 };
 
-#if defined SHARED_MEMORY && defined UNSTABLE
+#if defined Z_FEATURE_SHARED_MEMORY && defined Z_FEATURE_UNSTABLE_API
 class SHMAllocator {
     PosixShmProvider provider;
 
@@ -205,7 +205,7 @@ void test_with_alloc() {
 
 int main(int argc, char** argv) {
     test_with_alloc<CommonAllocator>();
-#if defined SHARED_MEMORY && defined UNSTABLE
+#if defined Z_FEATURE_SHARED_MEMORY && defined Z_FEATURE_UNSTABLE_API
     test_with_alloc<SHMAllocator>();
     test_with_alloc<SHMAllocator, false>();
 #endif


### PR DESCRIPTION
prepend feature macros with Z_FEATURE to avoid name collisions