### PR TITLE
[Fix] Add missing pragma once

### DIFF
--- a/include/zenoh/api/ext/serialization.hxx
+++ b/include/zenoh/api/ext/serialization.hxx
@@ -11,6 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 
+#pragma once
+
 #include <array>
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
`serialization.hxx` is missing `#pragma once` 