### PR TITLE
fix clang-fromat runner to ubuntu24.04 and print clang-format version in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run clang-format dry-run
-        run: find include/ tests/ examples/ -iname "*.hxx" -o -iname "*.cxx" | xargs clang-format -n -Werror
+        shell: bash
+        run: |
+          clang-format --version
+          find include/ tests/ examples/ -iname "*.hxx" -o -iname "*.cxx" | xargs clang-format -n -Werror
 
   build:
     name: Build on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   check_format:
     name: Check codebase format with clang-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
print clang-format version in ci;
hardcode ubuntu24.04 as runner for running clang-format job, to avoid unexpected clang-format version changes.