### PR TITLE
Add Bytes serialization support for std::span

### DIFF
--- a/examples/universal/z_bytes.cxx
+++ b/examples/universal/z_bytes.cxx
@@ -17,6 +17,10 @@
 #include "entity.pb.h"
 #endif
 
+#if __cplusplus >= 202002L
+#include <span>
+#endif
+
 #include "zenoh.hxx"
 using namespace zenoh;
 
@@ -90,6 +94,16 @@ int _main(int argc, char** argv) {
         const auto output = ext::deserialize<std::unordered_map<uint64_t, std::string>>(payload);
         assert(input == output);
     }
+
+    // Span
+    #if __cplusplus >= 202002L
+    {
+      double input[] = {1.0, 2.0, 3.0, 4.0};
+      const auto payload = ext::serialize(std::span(input));
+      const auto output = ext::deserialize<std::vector<double>>(payload);
+      assert(std::equal(std::begin(input), std::end(input), std::begin(output)));
+    }
+    #endif
 
     // Serializer, deserializer (for struct or tuple serialization)
     {

--- a/include/zenoh/api/ext/serialization.hxx
+++ b/include/zenoh/api/ext/serialization.hxx
@@ -13,6 +13,9 @@
 
 #pragma once
 
+#if __cplusplus >= 202002L
+#include <span>
+#endif
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -235,6 +238,15 @@ bool __zenoh_serialize_with_serializer(zenoh::ext::Serializer& serializer, const
                                        ZResult* err) {
     return __serialize_sequence_with_serializer(serializer, value.begin(), value.end(), value.size(), err);
 }
+
+#if __cplusplus >= 202002L
+template <class T, std::size_t Extent>
+bool __zenoh_serialize_with_serializer(zenoh::ext::Serializer& serializer, std::span<T, Extent> value,
+                                       ZResult* err) {
+    return __serialize_sequence_with_serializer(serializer, value.begin(), value.end(), value.size(), err);
+}
+#endif
+
 
 template <class T>
 bool serialize_with_serializer(zenoh::ext::Serializer& serializer, const T& t, ZResult* err) {


### PR DESCRIPTION
Makes it easy to use old style arrays + pointers with size without allocating memory.