### PR TITLE
chore: update org secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,8 +133,8 @@ jobs:
           version: ${{ needs.tag.outputs.version }}
           ssh-host: genie.zenoh@projects-storage.eclipse.org
           ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/zenoh-cpp
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
+          ssh-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          ssh-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
           archive-patterns: '.*\.zip'
 
   github:


### PR DESCRIPTION
As per eclipse-zenoh/.eclipsefdn#18, secrets were updated to follow eclipse foundation naming convention.