### PR TITLE
Script shell compatibility fix

### DIFF
--- a/scripts/install_from_git.sh
+++ b/scripts/install_from_git.sh
@@ -20,7 +20,7 @@ if [ "$#" -ge 3 ]; then
     USE_SHARED_MEMORY=$3
 fi
 
-if ("$USE_UNSTABLE" == "TRUE"); then
+if [ "$USE_UNSTABLE" == "TRUE" ]; then
     USE_UNSTABLE_PICO="1"
 fi
 


### PR DESCRIPTION
Not all shells support "if ()", changed to "if []"
Also for consistency with the rest of the script.