### PR TITLE
fix liveliness examples not being built for zenoh-pico if zenoh-c is disabled

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -56,12 +56,6 @@ function(add_examples glob mode lib)
 			endif()
 		endif()
 
-		if(NOT(ZENOHC_BUILD_WITH_UNSTABLE_API))
-			if(${file} MATCHES ".*liveliness.*$")
-				continue()
-			endif()
-		endif()
-
 		if(("${mode}" STREQUAL "zenohc") AND (NOT(ZENOHC_BUILD_WITH_UNSTABLE_API)))
 			if(${file} MATCHES ".*liveliness.*$")
 				continue()


### PR DESCRIPTION
fix liveliness examples not being built for zenoh-pico if zenoh-c is disabled