### PR TITLE
Fix z_queryable example output

### DIFF
--- a/examples/universal/z_queryable.cxx
+++ b/examples/universal/z_queryable.cxx
@@ -52,9 +52,10 @@ int _main(int argc, char **argv) {
     std::cout << "Declaring Queryable on '" << keyexpr << "'...\n";
 
     auto on_query = [payload, keyexpr](const Query &query) {
+        auto query_keyexpr = query.get_keyexpr();
         auto params = query.get_parameters();
         auto query_payload = query.get_payload();
-        std::cout << ">> [Queryable ] Received Query '" << keyexpr << "?" << params;
+        std::cout << ">> [Queryable ] Received Query '" << query_keyexpr.as_string_view() << "?" << params;
         if (query_payload.has_value()) {
             std::cout << "' with value = '" << query_payload->get().as_string();
         }


### PR DESCRIPTION
z_queryable output was printing its own keyexpr instead of the query's keyexpr.