### PR TITLE
Use 8 bytes payload as reference throughput value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The `z_querier` should continuously send queries and receive replies from `z_que
 ```
 
 ```bash
-./z_pub_thr_cpp 1024
+./z_pub_thr_cpp 8
 ```
 
 After 30-40 seconds delay the `z_sub_thr` will start to show the throughput measure results.


### PR DESCRIPTION
8 bytes payload is the reference payload size when measuring throughput. It would be hence good to update the value on the README.