### PR TITLE
Addes missing include to zshm

### DIFF
--- a/include/zenoh/api/shm/buffer/zshm.hxx
+++ b/include/zenoh/api/shm/buffer/zshm.hxx
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <functional>
 #include <optional>
 
 #include "../../base.hxx"


### PR DESCRIPTION
Related with this issue in rmw_zenoh_cpp https://github.com/ros2/rmw_zenoh/issues/350 when building in ubuntu 20.04