### PR TITLE
fix std::string&& to zenoh::Bytes conversion to use proper string length instead of null-terminator

### DIFF
--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -94,7 +94,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
         using Dval = std::remove_reference_t<D>;
         using DroppableType = typename detail::closures::Droppable<Dval>;
         auto drop = DroppableType::into_context(std::forward<D>(d));
-        ::z_bytes_from_str(interop::as_owned_c_ptr(*this), const_cast<char*>(ptr->c_str()),
+        ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), reinterpret_cast<uint8_t*>(ptr->data()), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
 

--- a/tests/universal/bytes.cxx
+++ b/tests/universal/bytes.cxx
@@ -104,6 +104,11 @@ void from_into() {
     std::vector<uint8_t> v = {1, 2, 4, 5, 6, 7, 8, 9, 10};
     std::vector<uint8_t> v2 = v;
     std::string s = "abcdefg";
+    // add a couple of null terminators to ensure that they are also moved into payload
+    s.push_back('\0');
+    s.push_back('h');
+    s.push_back('\0');
+    s.push_back('i');
     std::string s2 = s;
 
     Bytes bv(v), bs(s), bv2(std::move(v2)), bs2(std::move(s2));


### PR DESCRIPTION
merge from connoranderson:connor/fix_str_tmp_conversion (#345)