### PR TITLE
Conditionally build examples and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ status_print(project_version)
 declare_cache_var(ZENOHCXX_ZENOHC ON BOOL "Build for Zenoh-c target")
 declare_cache_var(ZENOHCXX_ZENOHPICO OFF BOOL "Build for Zenoh-pico target")
 declare_cache_var(ZENOHCXX_EXAMPLES_PROTOBUF ON BOOL "Build Protobuf example (turn off if you have problems with installed Protobuf version)")
+declare_cache_var(ZENOHCXX_ENABLE_TESTS ON BOOL "Enable building tests")
+declare_cache_var(ZENOHCXX_ENABLE_EXAMPLES ON BOOL "Enable building examples")
 
 set_default_build_type(Release)
 
@@ -70,7 +72,17 @@ endif()
 
 
 add_subdirectory(install)
-enable_testing()
-add_subdirectory(tests)
-add_subdirectory(examples)
+
+if(ZENOHCXX_ENABLE_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+else()
+    message(STATUS "Tests are disabled.")
+endif()
+if(ZENOHCXX_ENABLE_EXAMPLES)
+    add_subdirectory(examples)
+else()
+    message(STATUS "Examples are disabled.")
+endif()
+
 add_subdirectory(docs)


### PR DESCRIPTION
Using zenoh-cpp in a project, having built and installed zenoh-c (1.0.0) I came across a build error from zenoh-cpp, it looked like this:

```
...
CMake Error at zenoh-cpp/cmake/helpers.cmake:103 (add_custom_command):
  Error evaluating generator expression:

    $<TARGET_RUNTIME_DLLS:warnings_zenohc>

  Expression did not evaluate to a known generator expression
Call Stack (most recent call first):
  zenoh-cpp/tests/CMakeLists.txt:39 (copy_dlls)
  zenoh-cpp/tests/CMakeLists.txt:105 (add_test_instance)
...
```
  
 this, but with multiple more of the same error.
 
The error itself is not my main problem, I overcame that problem by simply commenting out the add_subdirectory(..) for examples and tests. 
 
But the reason for this PR is because I, and others, only use zenoh-cpp as a library in my project, so I don't want to build neither the zenoh-cpp examples or tests. That is an internal part of the zenoh-cpp project, and not a needed or an added value part of my project.

I figured this could be "excluded" with some options, especially if they cause build problems.
 