### PR TITLE
liveliness crash fix

### DIFF
--- a/include/zenoh/api/base.hxx
+++ b/include/zenoh/api/base.hxx
@@ -77,6 +77,7 @@ class Owned {
                 auto p_loaned = ::z_loan_mut(v._0);
                 assert(p_loaned != nullptr);
                 ::z_take_from_loaned(&this->_0, p_loaned);
+                // drop not needed, it's job for destructor of `v`
             } else {
                 _0 = v._0;
                 ::z_internal_null(&v._0);
@@ -95,6 +96,7 @@ class Owned {
                 auto p_loaned = ::z_loan_mut(*pv);
                 assert(p_loaned != nullptr);
                 ::z_take_from_loaned(&this->_0, p_loaned);
+                ::z_drop(::z_move(*pv));
             } else {
                 _0 = *pv;
                 ::z_internal_null(pv);

--- a/include/zenoh/api/base.hxx
+++ b/include/zenoh/api/base.hxx
@@ -74,7 +74,9 @@ class Owned {
         if (this != &v) {
             ::z_drop(::z_move(this->_0));
             if constexpr (detail::is_take_from_loaned_available_v<OwnedType>) {
-                ::z_take_from_loaned(&this->_0, ::z_loan_mut(v._0));
+                auto p_loaned = ::z_loan_mut(v._0);
+                assert(p_loaned != nullptr);
+                ::z_take_from_loaned(&this->_0, p_loaned);
             } else {
                 _0 = v._0;
                 ::z_internal_null(&v._0);
@@ -90,7 +92,9 @@ class Owned {
     explicit Owned(OwnedType* pv) {
         if (pv != nullptr) {
             if constexpr (detail::is_take_from_loaned_available_v<OwnedType>) {
-                ::z_take_from_loaned(&this->_0, ::z_loan_mut(*pv));
+                auto p_loaned = ::z_loan_mut(*pv);
+                assert(p_loaned != nullptr);
+                ::z_take_from_loaned(&this->_0, p_loaned);
             } else {
                 _0 = *pv;
                 ::z_internal_null(pv);

--- a/include/zenoh/api/channels.hxx
+++ b/include/zenoh/api/channels.hxx
@@ -126,10 +126,12 @@ class FifoHandler : public Owned<typename detail::FifoHandlerData<T>::handler_ty
     /// arrives.
     /// @return received data entry, if there were any in the buffer, a receive error otherwise.
     std::variant<T, RecvError> recv() const {
-        typename detail::FifoHandlerData<T>::owned_type t;
-        z_result_t res = ::z_recv(interop::as_loaned_c_ptr(*this), &t);
+        typename detail::FifoHandlerData<T>::owned_type ct;
+        z_result_t res = ::z_recv(interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
-            return T(&t);
+            T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
+            ::z_drop(::z_move(ct));
+            return t;
         } else {
             return RecvError::Z_DISCONNECTED;
         }
@@ -138,10 +140,12 @@ class FifoHandler : public Owned<typename detail::FifoHandlerData<T>::handler_ty
     /// @brief Fetch a data entry from the handler's buffer. If buffer is empty, will immediately return.
     /// @return received data entry, if there were any in the buffer, a receive error otherwise.
     std::variant<T, RecvError> try_recv() const {
-        typename T::OwnedType t;
-        z_result_t res = ::z_try_recv(interop::as_loaned_c_ptr(*this), &t);
+        typename detail::FifoHandlerData<T>::owned_type ct;
+        z_result_t res = ::z_try_recv(interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
-            return T(&t);
+            T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
+            ::z_drop(::z_move(ct));
+            return t;
         } else if (res == Z_CHANNEL_NODATA) {
             return RecvError::Z_NODATA;
         } else {
@@ -167,11 +171,13 @@ class RingHandler : public Owned<typename detail::RingHandlerData<T>::handler_ty
     /// arrives.
     /// @return received data, entry if there were any in the buffer, a receive error otherwise.
     std::variant<T, RecvError> recv() const {
-        typename T::OwnedType t;
+        typename detail::RingHandlerData<T>::owned_type ct;
         z_result_t res =
-            ::z_recv(zenoh::interop::as_loaned_c_ptr(*this), &t);
+            ::z_recv(zenoh::interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
-            return T(&t);
+            T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
+            ::z_drop(::z_move(ct));
+            return t;
         } else {
             return RecvError::Z_DISCONNECTED;
         }
@@ -180,10 +186,12 @@ class RingHandler : public Owned<typename detail::RingHandlerData<T>::handler_ty
     /// @brief Fetch a data entry from the handler's buffer. If buffer is empty, will immediately return.
     /// @return received data entry, if there were any in the buffer, a receive error otherwise.
     std::variant<T, RecvError> try_recv() const {
-        typename T::OwnedType t;
-        z_result_t res = ::z_try_recv(interop::as_loaned_c_ptr(*this), &t);
+        typename detail::RingHandlerData<T>::owned_type ct;
+        z_result_t res = ::z_try_recv(interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
-            return T(&t);
+            T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
+            ::z_drop(::z_move(ct));
+            return t;
         } else if (res == Z_CHANNEL_NODATA) {
             return RecvError::Z_NODATA;
         } else {

--- a/include/zenoh/api/channels.hxx
+++ b/include/zenoh/api/channels.hxx
@@ -172,8 +172,7 @@ class RingHandler : public Owned<typename detail::RingHandlerData<T>::handler_ty
     /// @return received data, entry if there were any in the buffer, a receive error otherwise.
     std::variant<T, RecvError> recv() const {
         typename detail::RingHandlerData<T>::owned_type ct;
-        z_result_t res =
-            ::z_recv(zenoh::interop::as_loaned_c_ptr(*this), &ct);
+        z_result_t res = ::z_recv(zenoh::interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
             T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
             ::z_drop(::z_move(ct));

--- a/include/zenoh/api/channels.hxx
+++ b/include/zenoh/api/channels.hxx
@@ -129,9 +129,7 @@ class FifoHandler : public Owned<typename detail::FifoHandlerData<T>::handler_ty
         typename detail::FifoHandlerData<T>::owned_type ct;
         z_result_t res = ::z_recv(interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
-            T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
-            ::z_drop(::z_move(ct));
-            return t;
+            return interop::detail::Converter::from_owned<T>(&ct);
         } else {
             return RecvError::Z_DISCONNECTED;
         }
@@ -143,9 +141,7 @@ class FifoHandler : public Owned<typename detail::FifoHandlerData<T>::handler_ty
         typename detail::FifoHandlerData<T>::owned_type ct;
         z_result_t res = ::z_try_recv(interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
-            T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
-            ::z_drop(::z_move(ct));
-            return t;
+            return interop::detail::Converter::from_owned<T>(&ct);
         } else if (res == Z_CHANNEL_NODATA) {
             return RecvError::Z_NODATA;
         } else {
@@ -174,9 +170,7 @@ class RingHandler : public Owned<typename detail::RingHandlerData<T>::handler_ty
         typename detail::RingHandlerData<T>::owned_type ct;
         z_result_t res = ::z_recv(zenoh::interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
-            T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
-            ::z_drop(::z_move(ct));
-            return t;
+            return interop::detail::Converter::from_owned<T>(&ct);
         } else {
             return RecvError::Z_DISCONNECTED;
         }
@@ -188,9 +182,7 @@ class RingHandler : public Owned<typename detail::RingHandlerData<T>::handler_ty
         typename detail::RingHandlerData<T>::owned_type ct;
         z_result_t res = ::z_try_recv(interop::as_loaned_c_ptr(*this), &ct);
         if (res == Z_OK) {
-            T t(std::move(interop::as_owned_cpp_ref<T>(&ct)));
-            ::z_drop(::z_move(ct));
-            return t;
+            return interop::detail::Converter::from_owned<T>(&ct);
         } else if (res == Z_CHANNEL_NODATA) {
             return RecvError::Z_NODATA;
         } else {

--- a/include/zenoh/api/hello.hxx
+++ b/include/zenoh/api/hello.hxx
@@ -26,7 +26,7 @@ namespace zenoh {
 /// message.
 class Hello : public Owned<::z_owned_hello_t> {
     Hello(zenoh::detail::null_object_t) : Owned(nullptr) {};
-    explicit Hello(OwnedType* pv) : Owned(pv) {};
+    explicit Hello(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/hello.hxx
+++ b/include/zenoh/api/hello.hxx
@@ -25,7 +25,7 @@ namespace zenoh {
 /// ``Hello`` message returned by a zenoh entity as a reply to a "scout"
 /// message.
 class Hello : public Owned<::z_owned_hello_t> {
-    Hello(zenoh::detail::null_object_t) : Owned(nullptr) {};
+    Hello(zenoh::detail::null_object_t) : Owned(nullptr){};
     explicit Hello(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 

--- a/include/zenoh/api/hello.hxx
+++ b/include/zenoh/api/hello.hxx
@@ -25,6 +25,10 @@ namespace zenoh {
 /// ``Hello`` message returned by a zenoh entity as a reply to a "scout"
 /// message.
 class Hello : public Owned<::z_owned_hello_t> {
+   Hello(zenoh::detail::null_object_t) : Owned(nullptr){};
+   explicit Hello(OwnedType* pv) : Owned(pv){};
+   friend struct interop::detail::Converter;
+
    public:
     /// @name Methods
 

--- a/include/zenoh/api/hello.hxx
+++ b/include/zenoh/api/hello.hxx
@@ -25,9 +25,9 @@ namespace zenoh {
 /// ``Hello`` message returned by a zenoh entity as a reply to a "scout"
 /// message.
 class Hello : public Owned<::z_owned_hello_t> {
-   Hello(zenoh::detail::null_object_t) : Owned(nullptr){};
-   explicit Hello(OwnedType* pv) : Owned(pv){};
-   friend struct interop::detail::Converter;
+    Hello(zenoh::detail::null_object_t) : Owned(nullptr) {};
+    explicit Hello(OwnedType* pv) : Owned(pv) {};
+    friend struct interop::detail::Converter;
 
    public:
     /// @name Methods

--- a/include/zenoh/api/interop.hxx
+++ b/include/zenoh/api/interop.hxx
@@ -170,7 +170,7 @@ auto& as_copyable_cpp_ref(CopyableType* copyable_c_obj) {
     return *reinterpret_cast<T*>(c_cpp);
 }
 
-/// @brief Move owned Zenoh zenoh-cpp object object into zenoh-c struct.
+/// @brief Move Zenoh zenoh-cpp object into owned zenoh-c struct.
 template <class OwnedType>
 OwnedType move_to_c_obj(Owned<OwnedType>&& owned_cpp_obj) {
     OwnedType o = *as_owned_c_ptr(owned_cpp_obj);
@@ -198,7 +198,13 @@ struct Converter {
     static auto to_c_opts(OPTIONS& options) {
         return options.to_c_opts();
     }
+
+    template <class T>
+    static T from_owned(typename T::OwnedType* owned) {
+        return T(owned);
+    }
 };
+
 
 template <class T>
 T null() {

--- a/include/zenoh/api/interop.hxx
+++ b/include/zenoh/api/interop.hxx
@@ -205,7 +205,6 @@ struct Converter {
     }
 };
 
-
 template <class T>
 T null() {
     return Converter::null_owned<T>();

--- a/include/zenoh/api/keyexpr.hxx
+++ b/include/zenoh/api/keyexpr.hxx
@@ -28,6 +28,7 @@ namespace zenoh {
 
 class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     KeyExpr(zenoh::detail::null_object_t) : Owned(nullptr){};
+    explicit KeyExpr(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/liveliness.hxx
+++ b/include/zenoh/api/liveliness.hxx
@@ -29,6 +29,7 @@ class Session;
 /// between the subscriber and the token's creator is lost.
 class LivelinessToken : public Owned<::z_owned_liveliness_token_t> {
     LivelinessToken(zenoh::detail::null_object_t) : Owned(nullptr){};
+    explicit LivelinessToken(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/query.hxx
+++ b/include/zenoh/api/query.hxx
@@ -33,6 +33,7 @@ namespace zenoh {
 /// The query to be answered by a ``Queryable``.
 class Query : public Owned<::z_owned_query_t> {
     Query(zenoh::detail::null_object_t) : Owned(nullptr){};
+    explicit Query(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/reply.hxx
+++ b/include/zenoh/api/reply.hxx
@@ -51,6 +51,7 @@ class ReplyError : public Owned<::z_owned_reply_err_t> {
 /// A reply from queryable to ``Session::get`` operation.
 class Reply : public Owned<::z_owned_reply_t> {
     Reply(zenoh::detail::null_object_t) : Owned(nullptr){};
+    explicit Reply(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/sample.hxx
+++ b/include/zenoh/api/sample.hxx
@@ -32,6 +32,7 @@ namespace zenoh {
 /// A sample is the value associated to a given resource at a given point in time.
 class Sample : public Owned<::z_owned_sample_t> {
     Sample(zenoh::detail::null_object_t) : Owned(nullptr){};
+    explicit Sample(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:


### PR DESCRIPTION
Move constructor validates that loan mut doesn't return nullptr: this may happen if trying to move from null value.
Channel code corrected to ensure that null object not passed to loan function