### PR TITLE
liveliness example crash fixed

### DIFF
--- a/include/zenoh/api/base.hxx
+++ b/include/zenoh/api/base.hxx
@@ -74,7 +74,12 @@ class Owned {
         if (this != &v) {
             ::z_drop(::z_move(this->_0));
             if constexpr (detail::is_take_from_loaned_available_v<OwnedType>) {
-                ::z_take_from_loaned(&this->_0, ::z_loan_mut(v._0));
+                auto p = ::z_loan_mut(v._0);
+                if (p != nullptr) {
+                    ::z_take_from_loaned(&this->_0, p);
+                } else {
+                    ::z_internal_null(&this->_0);
+                }
             } else {
                 _0 = v._0;
                 ::z_internal_null(&v._0);
@@ -90,7 +95,12 @@ class Owned {
     explicit Owned(OwnedType* pv) {
         if (pv != nullptr) {
             if constexpr (detail::is_take_from_loaned_available_v<OwnedType>) {
-                ::z_take_from_loaned(&this->_0, ::z_loan_mut(*pv));
+                auto p = ::z_loan_mut(*pv);
+                if (p != nullptr) {
+                    ::z_take_from_loaned(&this->_0, p);
+                } else {
+                    ::z_internal_null(&this->_0);
+                }
             } else {
                 _0 = *pv;
                 ::z_internal_null(pv);


### PR DESCRIPTION
Until https://github.com/eclipse-zenoh/zenoh-c/issues/925 is done the `z_loan` / `z_loan_mut` may return null, so need to check for it. Altertnative solution is #432 