### PR TITLE
Fix std::move operation for owned objects in null state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           find include/ tests/ examples/ -iname "*.hxx" -o -iname "*.cxx" | xargs clang-format -n -Werror
 
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.os }} in ${{ matrix.build_type }} unstable ${{ matrix.unstable }}  shm ${{ matrix.shm }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -41,13 +41,13 @@ jobs:
       - name: install zenoh-cpp and its dependencies
         shell: bash
         run: |
-          ./scripts/install_from_git.sh ~/local ${{ matrix.unstable }} ${{ matrix.shm }} ${{ matrix.build_type }}
+          ./scripts/install_from_git.sh ~/local ${{ matrix.unstable }} ${{ matrix.shm }} ON ${{ matrix.build_type }}
 
       - name: make examples
         shell: bash
         run: |
           cd build
-          cmake --build . --target examples --config Release
+          cmake --build . --target examples --config ${{ matrix.build_type }}
 
       - name: make stand-alone examples
         shell: bash
@@ -58,19 +58,19 @@ jobs:
         shell: bash
         run: |
           cd build
-          cmake --build . --target tests --config Release
+          cmake --build . --target tests --config ${{ matrix.build_type }}
 
       - name: run tests
         shell: bash
         run: |
           cd build
-          ctest -C Release --output-on-failure
+          ctest -C ${{ matrix.build_type }} --output-on-failure
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           # Artifact name
-          name: zenoh-cpp-${{ matrix.os }}
+          name: zenoh-cpp-${{ matrix.os }}-${{ matrix.build_type }}
           # Directory containing files to upload
           path: |
             target/release/examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         shm: [FALSE, TRUE]
         unstable: [FALSE, TRUE]
         build_type: [Debug, Release]
+        exclude:
+          - os: windows-latest
+            build_type: Debug
+            shm: TRUE
 
     steps:
       - name: Clone this repository

--- a/include/zenoh/api/base.hxx
+++ b/include/zenoh/api/base.hxx
@@ -74,10 +74,7 @@ class Owned {
         if (this != &v) {
             ::z_drop(::z_move(this->_0));
             if constexpr (detail::is_take_from_loaned_available_v<OwnedType>) {
-                auto p_loaned = ::z_loan_mut(v._0);
-                assert(p_loaned != nullptr);
-                ::z_take_from_loaned(&this->_0, p_loaned);
-                // drop not needed, it's job for destructor of `v`
+                ::z_take_from_loaned(&this->_0, ::z_loan_mut(v._0));
             } else {
                 _0 = v._0;
                 ::z_internal_null(&v._0);
@@ -93,10 +90,7 @@ class Owned {
     explicit Owned(OwnedType* pv) {
         if (pv != nullptr) {
             if constexpr (detail::is_take_from_loaned_available_v<OwnedType>) {
-                auto p_loaned = ::z_loan_mut(*pv);
-                assert(p_loaned != nullptr);
-                ::z_take_from_loaned(&this->_0, p_loaned);
-                ::z_drop(::z_move(*pv));
+                ::z_take_from_loaned(&this->_0, ::z_loan_mut(*pv));
             } else {
                 _0 = *pv;
                 ::z_internal_null(pv);

--- a/include/zenoh/api/hello.hxx
+++ b/include/zenoh/api/hello.hxx
@@ -25,10 +25,6 @@ namespace zenoh {
 /// ``Hello`` message returned by a zenoh entity as a reply to a "scout"
 /// message.
 class Hello : public Owned<::z_owned_hello_t> {
-    Hello(zenoh::detail::null_object_t) : Owned(nullptr){};
-    explicit Hello(OwnedType* pv) : Owned(pv){};
-    friend struct interop::detail::Converter;
-
    public:
     /// @name Methods
 

--- a/include/zenoh/api/interop.hxx
+++ b/include/zenoh/api/interop.hxx
@@ -170,7 +170,7 @@ auto& as_copyable_cpp_ref(CopyableType* copyable_c_obj) {
     return *reinterpret_cast<T*>(c_cpp);
 }
 
-/// @brief Move Zenoh zenoh-cpp object into owned zenoh-c struct.
+/// @brief Move owned Zenoh zenoh-cpp object object into zenoh-c struct.
 template <class OwnedType>
 OwnedType move_to_c_obj(Owned<OwnedType>&& owned_cpp_obj) {
     OwnedType o = *as_owned_c_ptr(owned_cpp_obj);
@@ -197,11 +197,6 @@ struct Converter {
     template <class OPTIONS>
     static auto to_c_opts(OPTIONS& options) {
         return options.to_c_opts();
-    }
-
-    template <class T>
-    static T from_owned(typename T::OwnedType* owned) {
-        return T(owned);
     }
 };
 

--- a/include/zenoh/api/keyexpr.hxx
+++ b/include/zenoh/api/keyexpr.hxx
@@ -28,7 +28,6 @@ namespace zenoh {
 
 class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     KeyExpr(zenoh::detail::null_object_t) : Owned(nullptr){};
-    explicit KeyExpr(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/liveliness.hxx
+++ b/include/zenoh/api/liveliness.hxx
@@ -29,7 +29,6 @@ class Session;
 /// between the subscriber and the token's creator is lost.
 class LivelinessToken : public Owned<::z_owned_liveliness_token_t> {
     LivelinessToken(zenoh::detail::null_object_t) : Owned(nullptr){};
-    explicit LivelinessToken(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/query.hxx
+++ b/include/zenoh/api/query.hxx
@@ -33,7 +33,6 @@ namespace zenoh {
 /// The query to be answered by a ``Queryable``.
 class Query : public Owned<::z_owned_query_t> {
     Query(zenoh::detail::null_object_t) : Owned(nullptr){};
-    explicit Query(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/reply.hxx
+++ b/include/zenoh/api/reply.hxx
@@ -51,7 +51,6 @@ class ReplyError : public Owned<::z_owned_reply_err_t> {
 /// A reply from queryable to ``Session::get`` operation.
 class Reply : public Owned<::z_owned_reply_t> {
     Reply(zenoh::detail::null_object_t) : Owned(nullptr){};
-    explicit Reply(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/include/zenoh/api/sample.hxx
+++ b/include/zenoh/api/sample.hxx
@@ -32,7 +32,6 @@ namespace zenoh {
 /// A sample is the value associated to a given resource at a given point in time.
 class Sample : public Owned<::z_owned_sample_t> {
     Sample(zenoh::detail::null_object_t) : Owned(nullptr){};
-    explicit Sample(OwnedType* pv) : Owned(pv){};
     friend struct interop::detail::Converter;
 
    public:

--- a/scripts/install_from_git.sh
+++ b/scripts/install_from_git.sh
@@ -3,7 +3,7 @@ set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ "$#" -eq 0 ]; then
-    echo "Usage: install_from_git INSTALL_PATH [BUILD_WITH_UNSTABLE_API] [BUILD_WITH_SHARED_MEMORY] [BUILD_TYPE] [BUILD_PICO]"
+    echo "Usage: install_from_git INSTALL_PATH [BUILD_WITH_UNSTABLE_API] [BUILD_WITH_SHARED_MEMORY] [BUILD_PICO] [BUILD_TYPE]"
     exit
 fi
 
@@ -26,12 +26,14 @@ if [ "$USE_UNSTABLE" == "TRUE" ] || [ "$USE_UNSTABLE" == "ON" ] || [ "$USE_UNSTA
 fi
 
 if [ "$#" -ge 4 ]; then
-    BUILD_TYPE=$4
+    BUILD_PICO=$4
 fi
 
 if [ "$#" -ge 5 ]; then
-    BUILD_PICO=$5
+    BUILD_TYPE=$5
 fi
+
+
 
 
 git submodule init
@@ -40,14 +42,14 @@ git submodule update
 mkdir -p $1
 absolute_install_location=$(cd $1; pwd)
 #build zenoh-c
-bash $SCRIPT_DIR/install_local.sh $SCRIPT_DIR/../zenoh-c $absolute_install_location -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DZENOHC_BUILD_WITH_UNSTABLE_API=$USE_UNSTABLE -DZENOHC_BUILD_WITH_SHARED_MEMORY=$USE_SHARED_MEMORY
+bash $SCRIPT_DIR/install_local.sh $SCRIPT_DIR/../zenoh-c $absolute_install_location $BUILD_TYPE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DZENOHC_BUILD_WITH_UNSTABLE_API=$USE_UNSTABLE -DZENOHC_BUILD_WITH_SHARED_MEMORY=$USE_SHARED_MEMORY
 if [ "$BUILD_PICO" == "ON" ] || [ "$BUILD_PICO" == "TRUE" ] || [ "$BUILD_PICO" == "1" ]; then
     #build zenoh-pico
-    bash $SCRIPT_DIR/install_local.sh $SCRIPT_DIR/../zenoh-pico $absolute_install_location -DZ_FEATURE_UNSTABLE_API=$USE_UNSTABLE_PICO
+    bash $SCRIPT_DIR/install_local.sh $SCRIPT_DIR/../zenoh-pico $absolute_install_location $BUILD_TYPE -DZ_FEATURE_UNSTABLE_API=$USE_UNSTABLE_PICO
 fi
 
 rm -rf ./build
 mkdir ./build
 cd ./build
 cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DZENOHCXX_ZENOHPICO=$BUILD_PICO  --install-prefix "$absolute_install_location"
-cmake --build . --target install
+cmake --build . --target install --config $BUILD_TYPE

--- a/scripts/install_from_local.sh
+++ b/scripts/install_from_local.sh
@@ -10,9 +10,9 @@ fi
 mkdir -p $1
 absolute_install_location=$(cd $1; pwd)
 #build zenoh-c
-bash $SCRIPT_DIR/install_local.sh $SCRIPT_DIR/../../zenoh-c $absolute_install_location -DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE -DZENOHC_BUILD_WITH_SHARED_MEMORY=TRUE
+bash $SCRIPT_DIR/install_local.sh $SCRIPT_DIR/../../zenoh-c $absolute_install_location Release -DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE -DZENOHC_BUILD_WITH_SHARED_MEMORY=TRUE
 #build zenoh-pico
-bash $SCRIPT_DIR/install_local.sh $SCRIPT_DIR/../../zenoh-pico $absolute_install_location -DZ_FEATURE_UNSTABLE_API=1
+bash $SCRIPT_DIR/install_local.sh $SCRIPT_DIR/../../zenoh-pico $absolute_install_location Release -DZ_FEATURE_UNSTABLE_API=1
 
 rm -rf ./build
 mkdir ./build

--- a/scripts/install_local.sh
+++ b/scripts/install_local.sh
@@ -2,9 +2,16 @@
 set -e
 
 if [ "$#" -eq 0 ]; then
-    echo "Usage: install_local PROJECT_PATH INSTALL_PATH [CMAKE_OPTIONS]"
+    echo "Usage: install_local PROJECT_PATH INSTALL_PATH [CONFIG] [CMAKE_ARGS]"
     exit
 fi
+
+CONFIG="Release"
+
+if [ "$#" -ge 3 ]; then
+    CONFIG=$3
+fi
+
 
 current_dir=$PWD
 project_folder=$1
@@ -16,5 +23,5 @@ cd "$project_folder"
 rm -rf ./build
 mkdir ./build
 cd ./build
-cmake .. "${@:3}" --install-prefix "$absolute_install_location"
-cmake --build . --target install
+cmake .. "${@:4}" --install-prefix "$absolute_install_location"
+cmake --build . --target install --config $CONFIG


### PR DESCRIPTION
Fix std::move operation for owned objects in null state.
Update ci to run tests in debug mode to catch related bugs in the future based on #430 .