### PR TITLE
Allow using zenohc as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,10 @@ set_default_build_type(Release)
 add_library(zenohcxx INTERFACE)
 target_include_directories(zenohcxx INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-if(ZENOHCXX_ZENOHPICO) 
-	find_package(zenohpico REQUIRED)
+if(ZENOHCXX_ZENOHPICO)
+	if(NOT TARGET zenohpico::lib) # Only find if target is not already available
+		find_package(zenohpico REQUIRED)
+	endif()
 	if(TARGET zenohpico::lib)
 		message(STATUS "defined lib target zenohcxx::zenohpico for zenohpico::lib")
 		add_library(zenohcxx_zenohpico INTERFACE)
@@ -56,7 +58,9 @@ if(ZENOHCXX_ZENOHPICO)
 endif()
 
 if(ZENOHCXX_ZENOHC)
-	find_package(zenohc REQUIRED)
+	if(NOT TARGET zenohc::lib) # Only find if target is not already available
+		find_package(zenohc REQUIRED)
+	endif()
 	if(TARGET zenohc::lib)
 		message(STATUS "defined lib target zenohcxx::zenohc::lib for zenohc::lib")
 		add_library(zenohcxx_zenohc INTERFACE)


### PR DESCRIPTION
By checking if the target actually exists before calling `FindPackage`, it is possible to either use `zenohc` and `zenohcxx` as a submodule in a project or add the projects via cmake's `FetchContent` mechanism.

The following works for me:

```cmake
include(FetchContent)

FetchContent_Declare(
  zenohc
  # URL https://github.com/eclipse-zenoh/zenoh-c/archive/refs/tags/1.4.0.zip
  # URL_HASH SHA256=28f5524da4681f5698391346cda2e252d7a1b7517b520b798d2290ab9fe65367
  GIT_REPOSITORY https://github.com/oleid/zenoh-c.git
  GIT_TAG fix/CMP0111
  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
)

FetchContent_Declare(
  zenohcxx
  # URL https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/1.4.0.zip
  # URL_HASH SHA256=017a9717e53478e8b015893b9025e8f9af803d665358fcd8c5963e4625ad0658
  GIT_REPOSITORY https://github.com/oleid/zenoh-cpp.git
  GIT_TAG feature/allow_submodule_build
  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
)

FetchContent_MakeAvailable(zenohc zenohcxx)
```