### PR TITLE
ci: run ctest with sudo to avoid permission error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         shm: ["FALSE", "TRUE"]
         unstable: ["FALSE", "TRUE"]
         build_type: [Debug, Release]
@@ -68,7 +68,12 @@ jobs:
         shell: bash
         run: |
           cd build
-          ctest -C ${{ matrix.build_type }} --output-on-failure
+          # On macOS, sudo is required to run tests due to LAN access permissions
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            sudo ctest -C ${{ matrix.build_type }} --output-on-failure
+          else
+            ctest -C ${{ matrix.build_type }} --output-on-failure
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
On macos-15 LAN access is required but the regular gh runner user doesn't have permission. Workaround by running as root.

See https://github.com/actions/runner-images/issues/10924