### PR TITLE
KeyExpression#as_string_view documentation Fix

### DIFF
--- a/include/zenoh/api/keyexpr.hxx
+++ b/include/zenoh/api/keyexpr.hxx
@@ -78,6 +78,7 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     /// @name Methods
 
     /// @brief Get underlying key expression string.
+    /// @return The key expression as a string_view.
     std::string_view as_string_view() const {
         ::z_view_string_t s;
         ::z_keyexpr_as_view_string(interop::as_loaned_c_ptr(*this), &s);

--- a/include/zenoh/api/keyexpr.hxx
+++ b/include/zenoh/api/keyexpr.hxx
@@ -76,6 +76,7 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     KeyExpr(KeyExpr&& other) = default;
 
     /// @name Methods
+
     /// @brief Get underlying key expression string.
     std::string_view as_string_view() const {
         ::z_view_string_t s;


### PR DESCRIPTION
The KeyExpression#as_string_view API is not visible in the official documentation - I believe due to missing empty line.

See https://zenoh-cpp.readthedocs.io/en/latest/keyexpr.html# and the screenshot:
<img width="806" height="816" alt="Screenshot from 2025-10-02 15-17-56" src="https://github.com/user-attachments/assets/c68d642f-006a-4ee3-ba39-ef7845274685" />
