### PR TITLE
Add missing interop.hxx header zenoh/api/config.hxx

### DIFF
--- a/include/zenoh/api/config.hxx
+++ b/include/zenoh/api/config.hxx
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "base.hxx"
+#include "interop.hxx"
 
 namespace zenoh {
 /// A Zenoh Session config.


### PR DESCRIPTION
Add missing interop.hxx header zenoh/api/config.hxx
Resolves #650 