### PR TITLE
Minor `#include` cleanup

### DIFF
--- a/include/zenoh/api/base.hxx
+++ b/include/zenoh/api/base.hxx
@@ -13,10 +13,9 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "../detail/availability_checks.hxx"
 #include "../zenohc.hxx"

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -14,18 +14,17 @@
 #pragma once
 
 #include "../detail/closures.hxx"
-#include "../detail/commons.hxx"
 #include "base.hxx"
-#include "closures.hxx"
 #include "interop.hxx"
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 #include "shm/buffer/buffer.hxx"
 #endif
 
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace zenoh {
@@ -81,10 +80,10 @@ class Bytes : public Owned<::z_owned_bytes_t> {
     }
 
     /// @brief Construct by copying sequence of charactes.
-    Bytes(const char* v) : Bytes(std::string_view(v)){};
+    Bytes(const char* v) : Bytes(std::string_view(v)) {};
 
     /// @brief Construct by copying sequence of charactes.
-    Bytes(const std::string& v) : Bytes(std::string_view(v)){};
+    Bytes(const std::string& v) : Bytes(std::string_view(v)) {};
 
     /// @brief Construct by moving a string.
     Bytes(std::string&& v) : Bytes() {

--- a/include/zenoh/api/channels.hxx
+++ b/include/zenoh/api/channels.hxx
@@ -16,6 +16,8 @@
 //
 
 #pragma once
+
+#include <utility>
 #include <variant>
 
 #include "base.hxx"
@@ -111,7 +113,7 @@ class FifoChannel;
 /// @tparam T data entry type.
 template <class T>
 class FifoHandler : public Owned<typename detail::FifoHandlerData<T>::handler_type> {
-    FifoHandler(zenoh::detail::null_object_t) : Owned<typename detail::FifoHandlerData<T>::handler_type>(nullptr){};
+    FifoHandler(zenoh::detail::null_object_t) : Owned<typename detail::FifoHandlerData<T>::handler_type>(nullptr) {};
 
    public:
     /// @name Methods
@@ -152,7 +154,7 @@ class RingChannel;
 /// @tparam T data entry type.
 template <class T>
 class RingHandler : public Owned<typename detail::RingHandlerData<T>::handler_type> {
-    RingHandler(zenoh::detail::null_object_t) : Owned<typename detail::RingHandlerData<T>::handler_type>(nullptr){};
+    RingHandler(zenoh::detail::null_object_t) : Owned<typename detail::RingHandlerData<T>::handler_type>(nullptr) {};
 
    public:
     /// @name Methods

--- a/include/zenoh/api/config.hxx
+++ b/include/zenoh/api/config.hxx
@@ -14,7 +14,7 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <string_view>
 
 #include "base.hxx"
 #include "interop.hxx"
@@ -22,7 +22,7 @@
 namespace zenoh {
 /// A Zenoh Session config.
 class Config : public Owned<::z_owned_config_t> {
-    Config(zenoh::detail::null_object_t) : Owned(nullptr){};
+    Config(zenoh::detail::null_object_t) : Owned(nullptr) {};
 
    public:
     /// @name Constructors

--- a/include/zenoh/api/encoding.hxx
+++ b/include/zenoh/api/encoding.hxx
@@ -12,7 +12,9 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 
 #pragma once
+
 #include <string>
+#include <string_view>
 
 #include "../zenohc.hxx"
 #include "base.hxx"

--- a/include/zenoh/api/enums.hxx
+++ b/include/zenoh/api/enums.hxx
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 
 #pragma once
+
 #include <string_view>
 
 #include "../zenohc.hxx"

--- a/include/zenoh/api/id.hxx
+++ b/include/zenoh/api/id.hxx
@@ -14,7 +14,6 @@
 #pragma once
 
 #include <array>
-#include <iomanip>
 #include <iostream>
 #include <string_view>
 

--- a/include/zenoh/api/keyexpr.hxx
+++ b/include/zenoh/api/keyexpr.hxx
@@ -12,6 +12,8 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 
 #pragma once
+
+#include <string>
 #include <string_view>
 
 #include "../zenohc.hxx"
@@ -27,7 +29,7 @@ namespace zenoh {
 /// when transporting key expressions.
 
 class KeyExpr : public Owned<::z_owned_keyexpr_t> {
-    KeyExpr(zenoh::detail::null_object_t) : Owned(nullptr){};
+    KeyExpr(zenoh::detail::null_object_t) : Owned(nullptr) {};
     friend struct interop::detail::Converter;
 
    public:
@@ -57,7 +59,7 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     /// @param err if not null, the result code will be written to this location, otherwise ZException exception will be
     /// thrown in case of error.
     KeyExpr(const std::string& key_expr, bool autocanonize = true, ZResult* err = nullptr)
-        : KeyExpr(static_cast<std::string_view>(key_expr), autocanonize, err){};
+        : KeyExpr(static_cast<std::string_view>(key_expr), autocanonize, err) {};
 
     /// @brief Create a new instance from a null-terminated string.
     ///
@@ -66,7 +68,7 @@ class KeyExpr : public Owned<::z_owned_keyexpr_t> {
     /// @param err if not null, the result code will be written to this location, otherwise ZException exception will be
     /// thrown in case of error.
     KeyExpr(const char* key_expr, bool autocanonize = true, ZResult* err = nullptr)
-        : KeyExpr(std::string_view(key_expr), autocanonize, err){};
+        : KeyExpr(std::string_view(key_expr), autocanonize, err) {};
 
     /// @brief Copy constructor.
     KeyExpr(const KeyExpr& other) : KeyExpr(zenoh::detail::null_object) {

--- a/include/zenoh/api/logging.hxx
+++ b/include/zenoh/api/logging.hxx
@@ -12,6 +12,9 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 
 #pragma once
+
+#include <string>
+
 #include "../zenohc.hxx"
 
 namespace zenoh {

--- a/include/zenoh/api/querier.hxx
+++ b/include/zenoh/api/querier.hxx
@@ -18,7 +18,9 @@
 #include "../detail/closures_concrete.hxx"
 #include "base.hxx"
 #include "bytes.hxx"
+#if defined(Z_FEATURE_UNSTABLE_API)
 #include "cancellation.hxx"
+#endif
 #include "encoding.hxx"
 #include "enums.hxx"
 #include "interop.hxx"

--- a/include/zenoh/api/session.hxx
+++ b/include/zenoh/api/session.hxx
@@ -40,7 +40,9 @@
 #include "shm/client_storage/client_storage.hxx"
 #include "shm/provider/shm_provider.hxx"
 #endif
+#if defined(Z_FEATURE_UNSTABLE_API)
 #include "cancellation.hxx"
+#endif
 
 namespace zenoh {
 namespace ext {

--- a/include/zenoh/detail/availability_checks.hxx
+++ b/include/zenoh/detail/availability_checks.hxx
@@ -12,7 +12,6 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #pragma once
 
-#include <optional>
 #include <type_traits>
 
 #include "../zenohc.hxx"

--- a/include/zenoh/detail/closures.hxx
+++ b/include/zenoh/detail/closures.hxx
@@ -20,7 +20,7 @@ namespace zenoh::detail::closures {
 
 struct IDroppable {
     virtual void drop() = 0;
-    virtual ~IDroppable(){};
+    virtual ~IDroppable() {};
 
     static void delete_from_context(void* context) {
         reinterpret_cast<IDroppable*>(context)->drop();

--- a/include/zenoh/detail/commons.hxx
+++ b/include/zenoh/detail/commons.hxx
@@ -14,6 +14,8 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 
 #include <iterator>
+#include <type_traits>
+#include <utility>
 
 namespace zenoh::detail::commons {
 


### PR DESCRIPTION
Explicitly `#include` used Standard Library headers, remove unused includes. This suppresses warnings/clang-tidy issues when building `zenoh-cpp` as a dependency.