### PR TITLE
Only drop channel handlers if throwing an exception in case of declaration/get failure

### DIFF
--- a/include/zenoh/api/ext/advanced_publisher.hxx
+++ b/include/zenoh/api/ext/advanced_publisher.hxx
@@ -187,8 +187,10 @@ class AdvancedPublisher : public Owned<::ze_owned_advanced_publisher_t> {
         auto m = zenoh::interop::detail::null<MatchingListener<void>>();
         zenoh::ZResult res = ::z_publisher_declare_matching_listener(
             interop::as_loaned_c_ptr(*this), interop::as_owned_c_ptr(m), ::z_move(cb_handler_pair.first));
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Matching Listener");
-        if (res != Z_OK) ::z_drop(zenoh::interop::as_moved_c_ptr(cb_handler_pair.second));
         return MatchingListener<typename Channel::template HandlerType<MatchingStatus>>(
             std::move(m), std::move(cb_handler_pair.second));
     }

--- a/include/zenoh/api/ext/advanced_subscriber.hxx
+++ b/include/zenoh/api/ext/advanced_subscriber.hxx
@@ -178,8 +178,10 @@ class AdvancedSubscriberBase : public Owned<::ze_owned_advanced_subscriber_t> {
         zenoh::ZResult res =
             ::z_liveliness_declare_subscriber(zenoh::interop::as_loaned_c_ptr(*this), zenoh::interop::as_owned_c_ptr(s),
                                               ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Liveliness Token Subscriber");
-        if (res != Z_OK) ::z_drop(::z_move(*zenoh::interop::as_moved_c_ptr(cb_handler_pair.second)));
         return zenoh::Subscriber<typename Channel::template HandlerType<zenoh::Sample>>(
             std::move(s), std::move(cb_handler_pair.second));
     }

--- a/include/zenoh/api/ext/session_ext.hxx
+++ b/include/zenoh/api/ext/session_ext.hxx
@@ -248,8 +248,10 @@ class SessionExt {
         zenoh::ZResult res = ::ze_declare_querying_subscriber(
             zenoh::interop::as_loaned_c_ptr(this->_session), zenoh::interop::as_owned_c_ptr(qs),
             zenoh::interop::as_loaned_c_ptr(key_expr), ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Querying Subscriber");
-        if (res != Z_OK) ::z_drop(zenoh::interop::as_moved_c_ptr(cb_handler_pair.second));
         return QueryingSubscriber<typename Channel::template HandlerType<zenoh::Sample>>(
             std::move(qs), std::move(cb_handler_pair.second));
     }
@@ -605,8 +607,10 @@ class SessionExt {
         zenoh::ZResult res = ::ze_declare_advanced_subscriber(
             zenoh::interop::as_loaned_c_ptr(this->_session), zenoh::interop::as_owned_c_ptr(s),
             zenoh::interop::as_loaned_c_ptr(key_expr), ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Advanced Subscriber");
-        if (res != Z_OK) ::z_drop(zenoh::interop::as_moved_c_ptr(cb_handler_pair.second));
         return AdvancedSubscriber<typename Channel::template HandlerType<Sample>>(std::move(s),
                                                                                   std::move(cb_handler_pair.second));
     }

--- a/include/zenoh/api/publisher.hxx
+++ b/include/zenoh/api/publisher.hxx
@@ -193,8 +193,10 @@ class Publisher : public Owned<::z_owned_publisher_t> {
         MatchingListener<void> m(zenoh::detail::null_object);
         ZResult res = ::z_publisher_declare_matching_listener(
             interop::as_loaned_c_ptr(*this), interop::as_owned_c_ptr(m), ::z_move(cb_handler_pair.first));
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Matching Listener");
-        if (res != Z_OK) ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
         return MatchingListener<typename Channel::template HandlerType<MatchingStatus>>(
             std::move(m), std::move(cb_handler_pair.second));
     }

--- a/include/zenoh/api/querier.hxx
+++ b/include/zenoh/api/querier.hxx
@@ -132,8 +132,10 @@ class Querier : public Owned<::z_owned_querier_t> {
 
         ZResult res = ::z_querier_get(interop::as_loaned_c_ptr(*this), parameters.c_str(),
                                       ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to perform Querier::get operation");
-        if (res != Z_OK) ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
         return std::move(cb_handler_pair.second);
     }
 
@@ -206,8 +208,10 @@ class Querier : public Owned<::z_owned_querier_t> {
         MatchingListener<void> m(zenoh::detail::null_object);
         ZResult res = ::z_querier_declare_matching_listener(interop::as_loaned_c_ptr(*this), interop::as_owned_c_ptr(m),
                                                             ::z_move(cb_handler_pair.first));
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Matching Listener");
-        if (res != Z_OK) ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
         return MatchingListener<typename Channel::template HandlerType<MatchingStatus>>(
             std::move(m), std::move(cb_handler_pair.second));
     }

--- a/include/zenoh/api/session.hxx
+++ b/include/zenoh/api/session.hxx
@@ -389,8 +389,10 @@ class Session : public Owned<::z_owned_session_t> {
 
         ZResult res = ::z_get(interop::as_loaned_c_ptr(*this), interop::as_loaned_c_ptr(key_expr), parameters.c_str(),
                               ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to perform get operation");
-        if (res != Z_OK) ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
         return std::move(cb_handler_pair.second);
     }
 #endif
@@ -504,8 +506,10 @@ class Session : public Owned<::z_owned_session_t> {
         Queryable<void> q(zenoh::detail::null_object);
         ZResult res = ::z_declare_queryable(interop::as_loaned_c_ptr(*this), interop::as_owned_c_ptr(q),
                                             interop::as_loaned_c_ptr(key_expr), ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Queryable");
-        if (res != Z_OK) ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
         return Queryable<typename Channel::template HandlerType<Query>>(std::move(q),
                                                                         std::move(cb_handler_pair.second));
     }
@@ -618,8 +622,10 @@ class Session : public Owned<::z_owned_session_t> {
         ZResult res =
             ::z_declare_subscriber(interop::as_loaned_c_ptr(*this), interop::as_owned_c_ptr(s),
                                    interop::as_loaned_c_ptr(key_expr), ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Subscriber");
-        if (res != Z_OK) ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
         return Subscriber<typename Channel::template HandlerType<Sample>>(std::move(s),
                                                                           std::move(cb_handler_pair.second));
     }
@@ -1163,8 +1169,10 @@ class Session : public Owned<::z_owned_session_t> {
         ZResult res = ::z_liveliness_declare_subscriber(interop::as_loaned_c_ptr(*this), interop::as_owned_c_ptr(s),
                                                         interop::as_loaned_c_ptr(key_expr),
                                                         ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to declare Liveliness Token Subscriber");
-        if (res != Z_OK) ::z_drop(::z_move(*interop::as_moved_c_ptr(cb_handler_pair.second)));
         return Subscriber<typename Channel::template HandlerType<Sample>>(std::move(s),
                                                                           std::move(cb_handler_pair.second));
     }
@@ -1247,8 +1255,10 @@ class Session : public Owned<::z_owned_session_t> {
 
         ZResult res = ::z_liveliness_get(interop::as_loaned_c_ptr(*this), interop::as_loaned_c_ptr(key_expr),
                                          ::z_move(cb_handler_pair.first), &opts);
+        if (res != Z_OK && err == nullptr) {
+            ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
+        }
         __ZENOH_RESULT_CHECK(res, err, "Failed to perform liveliness_get operation");
-        if (res != Z_OK) ::z_drop(interop::as_moved_c_ptr(cb_handler_pair.second));
         return std::move(cb_handler_pair.second);
     }
 #endif


### PR DESCRIPTION
Only drop channel handlers if throwing an exception in case of declaration/get failure