### PR TITLE
Fix zenoh pico connectivity guard for closures

### DIFF
--- a/include/zenoh/api.hxx
+++ b/include/zenoh/api.hxx
@@ -36,7 +36,7 @@
 #include "api/session.hxx"
 #include "api/subscriber.hxx"
 #include "api/timestamp.hxx"
-#if defined(Z_FEATURE_UNSTABLE_API)
+#if defined(Z_FEATURE_UNSTABLE_API) && (defined(ZENOHCXX_ZENOHC) || Z_FEATURE_CONNECTIVITY == 1)
 #include "api/link.hxx"
 #include "api/link_event.hxx"
 #include "api/link_events_listener.hxx"

--- a/include/zenoh/detail/closures_concrete.hxx
+++ b/include/zenoh/detail/closures_concrete.hxx
@@ -16,14 +16,14 @@
 #include "../api/hello.hxx"
 #include "../api/id.hxx"
 #include "../api/interop.hxx"
-#if defined(Z_FEATURE_UNSTABLE_API)
+#if defined(Z_FEATURE_UNSTABLE_API) && (defined(ZENOHCXX_ZENOHC) || Z_FEATURE_CONNECTIVITY == 1)
 #include "../api/link.hxx"
 #include "../api/link_event.hxx"
 #endif
 #include "../api/query.hxx"
 #include "../api/reply.hxx"
 #include "../api/sample.hxx"
-#if defined(Z_FEATURE_UNSTABLE_API)
+#if defined(Z_FEATURE_UNSTABLE_API) && (defined(ZENOHCXX_ZENOHC) || Z_FEATURE_CONNECTIVITY == 1)
 #include "../api/transport.hxx"
 #include "../api/transport_event.hxx"
 #endif
@@ -54,7 +54,7 @@ inline void _zenoh_on_id_call(const ::z_id_t* z_id, void* context) {
 inline void _zenoh_on_hello_call(::z_loaned_hello_t* hello, void* context) {
     IClosure<void, Hello&>::call_from_context(context, interop::as_owned_cpp_ref<Hello>(hello));
 }
-#if defined(Z_FEATURE_UNSTABLE_API)
+#if defined(Z_FEATURE_UNSTABLE_API) && (defined(ZENOHCXX_ZENOHC) || Z_FEATURE_CONNECTIVITY == 1)
 inline void _zenoh_on_transport_call(::z_loaned_transport_t* transport, void* context) {
     IClosure<void, Transport&>::call_from_context(context, interop::as_owned_cpp_ref<Transport>(transport));
 }


### PR DESCRIPTION
Fix zenoh pico connectivity guard for closures to check for Z_FEATURE_CONNECTIVITY==1