### PR TITLE
fix: Compile fix for MSVC 2022 in C++20 mode

### DIFF
--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -69,7 +69,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { delete ptr; };
         }; 
         using DroppableType = typename detail::closures::Droppable<VectorDeleter>;
-        auto drop = DroppableType::into_context(std::move(VectorDeleter{ptr}));
+        auto drop = DroppableType::into_context(VectorDeleter{ptr});
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr->data(), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
@@ -95,7 +95,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { delete ptr; }
         };
         using DroppableType = typename detail::closures::Droppable<StringDeleter>;
-        auto drop = DroppableType::into_context(std::move(StringDeleter{ptr}));
+        auto drop = DroppableType::into_context(StringDeleter{ptr});
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), reinterpret_cast<uint8_t*>(ptr->data()), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
@@ -116,7 +116,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { deleter(ptr); }
         };
         using DroppableType = typename detail::closures::Droppable<CustomDeleter>;
-        auto drop = DroppableType::into_context(std::move(CustomDeleter{ptr, std::move(deleter)}));
+        auto drop = DroppableType::into_context(CustomDeleter{ptr, std::move(deleter)});
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr, len, detail::closures::_zenoh_drop_with_context, drop);
     }
 

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -64,11 +64,12 @@ class Bytes : public Owned<::z_owned_bytes_t> {
     template <class Allocator>
     Bytes(std::vector<uint8_t, Allocator>&& v) : Bytes() {
         std::vector<uint8_t, Allocator>* ptr = new std::vector<uint8_t, Allocator>(std::move(v));
-        auto d = [p = ptr]() mutable { delete p; };
-        using D = decltype(d);
-        using Dval = std::remove_reference_t<D>;
-        using DroppableType = typename detail::closures::Droppable<Dval>;
-        auto drop = DroppableType::into_context(std::move(d));
+         struct VectorDeleter {
+            std::vector<uint8_t, Allocator>* ptr;
+            void operator()() { delete ptr; };
+        }; 
+        using DroppableType = typename detail::closures::Droppable<VectorDeleter>;
+        auto drop = DroppableType::into_context(std::move(VectorDeleter(ptr)));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr->data(), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
@@ -89,11 +90,12 @@ class Bytes : public Owned<::z_owned_bytes_t> {
     /// @brief Construct by moving a string.
     Bytes(std::string&& v) : Bytes() {
         std::string* ptr = new std::string(std::move(v));
-        auto d = [p = ptr]() mutable { delete p; };
-        using D = decltype(d);
-        using Dval = std::remove_reference_t<D>;
-        using DroppableType = typename detail::closures::Droppable<Dval>;
-        auto drop = DroppableType::into_context(std::move(d));
+        struct StringDeleter {
+            std::string* ptr;
+            void operator()() { delete ptr; }
+        };
+        using DroppableType = typename detail::closures::Droppable<StringDeleter>;
+        auto drop = DroppableType::into_context(std::move(StringDeleter(ptr)));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), reinterpret_cast<uint8_t*>(ptr->data()), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
@@ -108,11 +110,13 @@ class Bytes : public Owned<::z_owned_bytes_t> {
     Bytes(uint8_t* ptr, size_t len, Deleter deleter) : Bytes() {
         static_assert(std::is_invocable_r<void, Deleter, uint8_t*>::value,
                       "deleter should be callable with the following signature: void deleter(uint8_t* data)");
-        auto d = [p = ptr, del = std::move(deleter)]() mutable { del(p); };
-        using D = decltype(d);
-        using Dval = std::remove_reference_t<D>;
-        using DroppableType = typename detail::closures::Droppable<Dval>;
-        auto drop = DroppableType::into_context(std::move(d));
+        struct CustomDeleter {
+            uint8_t* ptr;
+            Deleter deleter;
+            void operator()() { deleter(ptr); }
+        };
+        using DroppableType = typename detail::closures::Droppable<CustomDeleter>;
+        auto drop = DroppableType::into_context(std::move(CustomDeleter(ptr, std::move(deleter))));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr, len, detail::closures::_zenoh_drop_with_context, drop);
     }
 

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -69,7 +69,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { delete ptr; };
         }; 
         using DroppableType = typename detail::closures::Droppable<VectorDeleter>;
-        auto drop = DroppableType::into_context(std::move(VectorDeleter(ptr)));
+        auto drop = DroppableType::into_context(std::move(VectorDeleter({.ptr = ptr})));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr->data(), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
@@ -95,7 +95,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { delete ptr; }
         };
         using DroppableType = typename detail::closures::Droppable<StringDeleter>;
-        auto drop = DroppableType::into_context(std::move(StringDeleter(ptr)));
+        auto drop = DroppableType::into_context(std::move(StringDeleter({.ptr = ptr})));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), reinterpret_cast<uint8_t*>(ptr->data()), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
@@ -116,7 +116,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { deleter(ptr); }
         };
         using DroppableType = typename detail::closures::Droppable<CustomDeleter>;
-        auto drop = DroppableType::into_context(std::move(CustomDeleter(ptr, std::move(deleter))));
+        auto drop = DroppableType::into_context(std::move(CustomDeleter({.ptr = ptr, .deleter = std::move(deleter)})));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr, len, detail::closures::_zenoh_drop_with_context, drop);
     }
 

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -82,10 +82,10 @@ class Bytes : public Owned<::z_owned_bytes_t> {
     }
 
     /// @brief Construct by copying sequence of charactes.
-    Bytes(const char* v) : Bytes(std::string_view(v)) {};
+    Bytes(const char* v) : Bytes(std::string_view(v)) {}
 
     /// @brief Construct by copying sequence of charactes.
-    Bytes(const std::string& v) : Bytes(std::string_view(v)) {};
+    Bytes(const std::string& v) : Bytes(std::string_view(v)) {}
 
     /// @brief Construct by moving a string.
     Bytes(std::string&& v) : Bytes() {

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -69,7 +69,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { delete ptr; };
         }; 
         using DroppableType = typename detail::closures::Droppable<VectorDeleter>;
-        auto drop = DroppableType::into_context(std::move(VectorDeleter({.ptr = ptr})));
+        auto drop = DroppableType::into_context(std::move(VectorDeleter{ptr}));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr->data(), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
@@ -95,7 +95,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { delete ptr; }
         };
         using DroppableType = typename detail::closures::Droppable<StringDeleter>;
-        auto drop = DroppableType::into_context(std::move(StringDeleter({.ptr = ptr})));
+        auto drop = DroppableType::into_context(std::move(StringDeleter{ptr}));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), reinterpret_cast<uint8_t*>(ptr->data()), ptr->size(),
                            detail::closures::_zenoh_drop_with_context, drop);
     }
@@ -116,7 +116,7 @@ class Bytes : public Owned<::z_owned_bytes_t> {
             void operator()() { deleter(ptr); }
         };
         using DroppableType = typename detail::closures::Droppable<CustomDeleter>;
-        auto drop = DroppableType::into_context(std::move(CustomDeleter({.ptr = ptr, .deleter = std::move(deleter)})));
+        auto drop = DroppableType::into_context(std::move(CustomDeleter{ptr, std::move(deleter)}));
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr, len, detail::closures::_zenoh_drop_with_context, drop);
     }
 

--- a/include/zenoh/api/bytes.hxx
+++ b/include/zenoh/api/bytes.hxx
@@ -64,10 +64,10 @@ class Bytes : public Owned<::z_owned_bytes_t> {
     template <class Allocator>
     Bytes(std::vector<uint8_t, Allocator>&& v) : Bytes() {
         std::vector<uint8_t, Allocator>* ptr = new std::vector<uint8_t, Allocator>(std::move(v));
-         struct VectorDeleter {
+        struct VectorDeleter {
             std::vector<uint8_t, Allocator>* ptr;
             void operator()() { delete ptr; };
-        }; 
+        };
         using DroppableType = typename detail::closures::Droppable<VectorDeleter>;
         auto drop = DroppableType::into_context(VectorDeleter{ptr});
         ::z_bytes_from_buf(interop::as_owned_c_ptr(*this), ptr->data(), ptr->size(),
@@ -82,10 +82,10 @@ class Bytes : public Owned<::z_owned_bytes_t> {
     }
 
     /// @brief Construct by copying sequence of charactes.
-    Bytes(const char* v) : Bytes(std::string_view(v)){};
+    Bytes(const char* v) : Bytes(std::string_view(v)) {};
 
     /// @brief Construct by copying sequence of charactes.
-    Bytes(const std::string& v) : Bytes(std::string_view(v)){};
+    Bytes(const std::string& v) : Bytes(std::string_view(v)) {};
 
     /// @brief Construct by moving a string.
     Bytes(std::string&& v) : Bytes() {

--- a/include/zenoh/detail/closures.hxx
+++ b/include/zenoh/detail/closures.hxx
@@ -55,7 +55,7 @@ class Droppable : public IDroppable {
 
     template <class DD>
     static void* into_context(DD&& drop) {
-        auto obj = new Droppable<std::remove_cvref_t<DD>>(std::forward<DD>(drop));
+        auto obj = new Droppable<D>(std::forward<DD>(drop));
         return obj->as_context();
     }
 };
@@ -75,7 +75,7 @@ class Closure : public IClosure<R, Args...> {
 
     template <class CC, class DD>
     static void* into_context(CC&& call, DD&& drop) {
-        auto obj = new Closure<std::remove_cvref_t<CC>, std::remove_cvref_t<DD>, R, Args...>(std::forward<CC>(call), std::forward<DD>(drop));
+        auto obj = new Closure<C, D, R, Args...>(std::forward<CC>(call), std::forward<DD>(drop));
         return obj->as_context();
     }
 };

--- a/include/zenoh/detail/closures.hxx
+++ b/include/zenoh/detail/closures.hxx
@@ -55,7 +55,7 @@ class Droppable : public IDroppable {
 
     template <class DD>
     static void* into_context(DD&& drop) {
-        auto obj = new Droppable<D>(std::forward<DD>(drop));
+        auto obj = new Droppable<std::remove_cvref_t<DD>>(std::forward<DD>(drop));
         return obj->as_context();
     }
 };
@@ -75,7 +75,7 @@ class Closure : public IClosure<R, Args...> {
 
     template <class CC, class DD>
     static void* into_context(CC&& call, DD&& drop) {
-        auto obj = new Closure<C, D, R, Args...>(std::forward<CC>(call), std::forward<DD>(drop));
+        auto obj = new Closure<std::remove_cvref_t<CC>, std::remove_cvref_t<DD>, R, Args...>(std::forward<CC>(call), std::forward<DD>(drop));
         return obj->as_context();
     }
 };


### PR DESCRIPTION
related to https://github.com/ros2/rmw_zenoh/pull/968

This fixed compilation errors with MSCV 2022 in C++20 mode.
Note, the minimum c++ standard will be raised to 20 for the L-Release.

