### PR TITLE
Support builds without exceptions

### DIFF
--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -15,9 +15,14 @@
 Error Handling
 ==============
 
-All failable Zenoh methods accept pointer to zenoh::ZResult as an optional argument.
-If it is not provided (or set to ``nullptr``) a ``zenoh::ZException`` will be thrown in case of failure.
-Otherwise a error code will be written to provided pointer and no exception will be thrown from Zenoh side.
+All failable Zenoh methods accept a pointer to ``zenoh::ZResult``.
+
+If the pointer is not ``nullptr``, the resulting error code is stored in the location it points to.
+If the pointer is ``nullptr`` and exceptions are enabled (which is usually the case), a ``zenoh::ZException`` is thrown on failure.
+If the pointer is ``nullptr`` and exceptions are disabled, ``abort()`` is called on failure.
+
+Therefore, when exceptions are unavailable, you must always provide a valid ``zenoh::ZResult`` pointer.
+
 If corresponding method is expected to return or consume (via ``std::move``) any objects, they will be reset to
 gravestone state (i.e. None of the functions or methods will work with the object in this state, except 
 explicit conversion to ``bool``, which will return false).

--- a/include/zenoh/api/base.hxx
+++ b/include/zenoh/api/base.hxx
@@ -26,6 +26,7 @@ namespace zenoh {
 /// @brief Error code returned by Zenoh API
 typedef ::z_result_t ZResult;
 
+#ifdef __cpp_exceptions
 /// @brief Zenoh-specific Exception
 class ZException : public std::runtime_error {
    public:
@@ -33,13 +34,17 @@ class ZException : public std::runtime_error {
     ZException(const std::string& message, ZResult err)
         : std::runtime_error(message + "(Error code: " + std::to_string(err) + " )"), e(err) {}
 };
+#define __ZENOH_THROW_ZEXCEPTION(msg, err) throw ZException(msg, err)
+#else
+#define __ZENOH_THROW_ZEXCEPTION(msg, err) abort();
+#endif
 
-#define __ZENOH_RESULT_CHECK(err, err_ptr, message)        \
-    if (err_ptr == nullptr) {                              \
-        ZResult __ze = static_cast<ZResult>(err);          \
-        if (__ze != Z_OK) throw ZException(message, __ze); \
-    } else {                                               \
-        *err_ptr = static_cast<ZResult>(err);              \
+#define __ZENOH_RESULT_CHECK(err, err_ptr, message)                \
+    if (err_ptr == nullptr) {                                      \
+        ZResult __ze = static_cast<ZResult>(err);                  \
+        if (__ze != Z_OK) __ZENOH_THROW_ZEXCEPTION(message, __ze); \
+    } else {                                                       \
+        *err_ptr = static_cast<ZResult>(err);                      \
     }
 
 //

--- a/include/zenoh/api/reply.hxx
+++ b/include/zenoh/api/reply.hxx
@@ -66,7 +66,7 @@ class Reply : public Owned<::z_owned_reply_t> {
     /// @return reply sample.
     const Sample& get_ok() const {
         if (!::z_reply_is_ok(interop::as_loaned_c_ptr(*this))) {
-            throw ZException("Reply data sample was requested, but reply contains error", Z_EINVAL);
+            __ZENOH_THROW_ZEXCEPTION("Reply data sample was requested, but reply contains error", Z_EINVAL);
         }
         return interop::as_owned_cpp_ref<Sample>(::z_reply_ok(interop::as_loaned_c_ptr(*this)));
     }
@@ -77,7 +77,7 @@ class Reply : public Owned<::z_owned_reply_t> {
     // /// @return reply sample.
     // Sample& get_ok() {
     //     if (!::z_reply_is_ok(interop::as_loaned_c_ptr(*this))) {
-    //         throw ZException("Reply data sample was requested, but reply contains error", Z_EINVAL);
+    //         __ZENOH_THROW_ZEXCEPTION("Reply data sample was requested, but reply contains error", Z_EINVAL);
     //     }
     //     return interop::as_owned_cpp_ref<Sample>(::z_reply_ok_mut(interop::as_loaned_c_ptr(*this)));
     // }
@@ -87,7 +87,7 @@ class Reply : public Owned<::z_owned_reply_t> {
     /// @return reply error.
     const ReplyError& get_err() const {
         if (::z_reply_is_ok(interop::as_loaned_c_ptr(*this))) {
-            throw ZException("Reply error was requested, but reply contains data sample", Z_EINVAL);
+            __ZENOH_THROW_ZEXCEPTION("Reply error was requested, but reply contains data sample", Z_EINVAL);
         }
         return interop::as_owned_cpp_ref<ReplyError>(::z_reply_err(interop::as_loaned_c_ptr(*this)));
     }
@@ -98,7 +98,7 @@ class Reply : public Owned<::z_owned_reply_t> {
     // /// @return reply error.
     // ReplyError& get_err() {
     //     if (::z_reply_is_ok(interop::as_loaned_c_ptr(*this))) {
-    //         throw ZException("Reply error was requested, but reply contains data sample", Z_EINVAL);
+    //         __ZENOH_THROW_ZEXCEPTION("Reply error was requested, but reply contains data sample", Z_EINVAL);
     //     }
     //     return interop::as_owned_cpp_ref<ReplyError>(::z_reply_err_mut(interop::as_loaned_c_ptr(*this)));
     // }


### PR DESCRIPTION
To be able to use zenoh-cpp in an exception free environment such as micro-controllers, the following minimally-invasive change provides a `THROW_ZEXCEPTION` macro, which compiles down to simply calling `abort()` if exceptions are disabled.

Since exceptions are the standard case, I think it doesn't make sense to change all the doxygen comments. I updated the documentation on error handling, though.