### PR TITLE
ci: bind zenoh router to private address during CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,40 +67,6 @@ jobs:
       - name: run tests
         shell: bash
         run: |
-          case "${{ runner.os }}" in
-            Linux)
-              RUNNER_IP="$({
-                ip route get 1.1.1.1 |
-                  awk '{ for (i = 1; i <= NF; i++) if ($i == "src") print $(i + 1) }'
-              })"
-              ;;
-            macOS)
-              INTERFACE="$(route -n get default | awk '/interface:/{print $2}')"
-              RUNNER_IP="$(ipconfig getifaddr "$INTERFACE")"
-              ;;
-            Windows)
-              RUNNER_IP="$(
-                powershell.exe -NoProfile -Command \
-                  '(Get-NetIPConfiguration | Where-Object {$_.IPv4DefaultGateway -ne $null} | Select-Object -First 1 -ExpandProperty IPv4Address).IPAddress'
-              )"
-              RUNNER_IP="$(printf '%s' "$RUNNER_IP" | tr -d '\r')"
-              ;;
-            *)
-              echo "::error::Unsupported runner OS: ${{ runner.os }}"
-              exit 1
-              ;;
-          esac
-
-          if [[ ! "$RUNNER_IP" =~ ^10\.[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
-             [[ ! "$RUNNER_IP" =~ ^192\.168\.[0-9]+\.[0-9]+$ ]] &&
-             [[ ! "$RUNNER_IP" =~ ^172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Resolved address is not a private IPv4 address: $RUNNER_IP"
-            exit 1
-          fi
-
-          export ZENOH_TEST_ROUTER_LISTENER="tcp/$RUNNER_IP:7447"
-          echo "Using Zenoh test router listener: $ZENOH_TEST_ROUTER_LISTENER"
-
           cd build
           # On ubuntu we need to modify memlock limit to allow tests to run
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
@@ -108,8 +74,7 @@ jobs:
           fi
           # On macOS, sudo is required to run tests due to LAN access permissions
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            sudo env "ZENOH_TEST_ROUTER_LISTENER=$ZENOH_TEST_ROUTER_LISTENER" \
-              ctest -C ${{ matrix.build_type }} --output-on-failure
+            sudo ctest -C ${{ matrix.build_type }} --output-on-failure
           else
             ctest -C ${{ matrix.build_type }} --output-on-failure
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,40 @@ jobs:
       - name: run tests
         shell: bash
         run: |
+          case "${{ runner.os }}" in
+            Linux)
+              RUNNER_IP="$({
+                ip route get 1.1.1.1 |
+                  awk '{ for (i = 1; i <= NF; i++) if ($i == "src") print $(i + 1) }'
+              })"
+              ;;
+            macOS)
+              INTERFACE="$(route -n get default | awk '/interface:/{print $2}')"
+              RUNNER_IP="$(ipconfig getifaddr "$INTERFACE")"
+              ;;
+            Windows)
+              RUNNER_IP="$(
+                powershell.exe -NoProfile -Command \
+                  '(Get-NetIPConfiguration | Where-Object {$_.IPv4DefaultGateway -ne $null} | Select-Object -First 1 -ExpandProperty IPv4Address).IPAddress'
+              )"
+              RUNNER_IP="$(printf '%s' "$RUNNER_IP" | tr -d '\r')"
+              ;;
+            *)
+              echo "::error::Unsupported runner OS: ${{ runner.os }}"
+              exit 1
+              ;;
+          esac
+
+          if [[ ! "$RUNNER_IP" =~ ^10\.[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
+             [[ ! "$RUNNER_IP" =~ ^192\.168\.[0-9]+\.[0-9]+$ ]] &&
+             [[ ! "$RUNNER_IP" =~ ^172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Resolved address is not a private IPv4 address: $RUNNER_IP"
+            exit 1
+          fi
+
+          export ZENOH_TEST_ROUTER_LISTENER="tcp/$RUNNER_IP:7447"
+          echo "Using Zenoh test router listener: $ZENOH_TEST_ROUTER_LISTENER"
+
           cd build
           # On ubuntu we need to modify memlock limit to allow tests to run
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
@@ -74,7 +108,8 @@ jobs:
           fi
           # On macOS, sudo is required to run tests due to LAN access permissions
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            sudo ctest -C ${{ matrix.build_type }} --output-on-failure
+            sudo env "ZENOH_TEST_ROUTER_LISTENER=$ZENOH_TEST_ROUTER_LISTENER" \
+              ctest -C ${{ matrix.build_type }} --output-on-failure
           else
             ctest -C ${{ matrix.build_type }} --output-on-failure
           fi

--- a/tests/run_with_router.sh
+++ b/tests/run_with_router.sh
@@ -17,6 +17,79 @@ TESTBIN="$1"
 TESTDIR=$(dirname "$0")
 ZENOH_BRANCH="$2"
 
+resolve_interface_ip() {
+    case "${RUNNER_OS:-$(uname -s)}" in
+        Linux)
+            {
+                ip route get 1.1.1.1 |
+                    awk '{ for (i = 1; i <= NF; i++) if ($i == "src") print $(i + 1) }'
+                ip -4 -o addr show scope global |
+                    awk '{ split($4, address, "/"); print address[1] }'
+            } | select_private_ipv4
+            ;;
+        macOS|Darwin)
+            {
+                INTERFACE=$(route -n get default | awk '/interface:/{print $2}')
+                ipconfig getifaddr "$INTERFACE"
+                ifconfig | awk '/inet /{print $2}'
+            } | select_private_ipv4
+            ;;
+        Windows|MINGW*|MSYS*)
+            powershell.exe -NoProfile -Command \
+                '(Get-NetIPAddress -AddressFamily IPv4 | Where-Object {$_.IPAddress -match "^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)"} | Select-Object -First 1).IPAddress' |
+                tr -d '\r'
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+select_private_ipv4() {
+    while IFS= read -r candidate; do
+        if is_private_ipv4 "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_valid_ipv4() {
+    printf '%s\n' "$1" | awk -F. '
+        NF != 4 { exit 1 }
+        {
+            for (i = 1; i <= 4; i++) {
+                if ($i !~ /^[0-9]+$/ || $i < 0 || $i > 255) exit 1
+            }
+        }
+    '
+}
+
+is_private_ipv4() {
+    case "$1" in
+        10.*|192.168.*|172.16.*|172.17.*|172.18.*|172.19.*|172.2[0-9].*|172.3[0-1].*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+if [ -z "${ZENOH_TEST_ROUTER_LISTENER:-}" ]; then
+    INTERFACE_IP=$(resolve_interface_ip)
+    if ! is_private_ipv4 "$INTERFACE_IP"; then
+        echo "ERROR: could not resolve a private IPv4 address for the test interface." >&2
+        echo "Resolved address: ${INTERFACE_IP:-<empty>}" >&2
+        echo "Set ZENOH_TEST_ROUTER_LISTENER to a concrete interface address before running ctest, or connect this machine to a private network." >&2
+        echo "Refusing to fall back to tcp/0.0.0.0:7447: that would expose the unauthenticated test router on every network interface." >&2
+        exit 1
+    fi
+    ZENOH_TEST_ROUTER_LISTENER="tcp/$INTERFACE_IP:7447"
+    export ZENOH_TEST_ROUTER_LISTENER
+fi
+
 # get vinary name without extension
 TEST_NAME_WE=$(basename -- "$TESTBIN")
 TEST_NAME_WE="${TEST_NAME_WE%.*}"
@@ -47,7 +120,7 @@ fi
 
 chmod +x zenohd
 
-LOCATORS="${ZENOH_TEST_ROUTER_LISTENER:-tcp/127.0.0.1:7447}"
+LOCATORS="$ZENOH_TEST_ROUTER_LISTENER"
 for LOCATOR in $(echo "$LOCATORS" | xargs); do
     sleep 1
 

--- a/tests/run_with_router.sh
+++ b/tests/run_with_router.sh
@@ -60,7 +60,7 @@ resolve_interface_ip() {
                     exit 1
                 }
             ' |
-                tr -d '\r'
+                tr -d '\015'
             ;;
         *)
             return 1

--- a/tests/run_with_router.sh
+++ b/tests/run_with_router.sh
@@ -20,23 +20,46 @@ ZENOH_BRANCH="$2"
 resolve_interface_ip() {
     case "${RUNNER_OS:-$(uname -s)}" in
         Linux)
-            {
-                ip route get 1.1.1.1 |
-                    awk '{ for (i = 1; i <= NF; i++) if ($i == "src") print $(i + 1) }'
-                ip -4 -o addr show scope global |
-                    awk '{ split($4, address, "/"); print address[1] }'
-            } | select_private_ipv4
+            ip route get 1.1.1.1 |
+                awk '{ for (i = 1; i <= NF; i++) if ($i == "src") { print $(i + 1); exit } }' |
+                select_private_ipv4
             ;;
         macOS|Darwin)
-            {
-                INTERFACE=$(route -n get default | awk '/interface:/{print $2}')
-                ipconfig getifaddr "$INTERFACE"
-                ifconfig | awk '/inet /{print $2}'
-            } | select_private_ipv4
+            INTERFACE=$(route -n get default | awk '/interface:/{print $2; exit}')
+            ipconfig getifaddr "$INTERFACE" | select_private_ipv4
             ;;
         Windows|MINGW*|MSYS*)
-            powershell.exe -NoProfile -Command \
-                '(Get-NetIPAddress -AddressFamily IPv4 | Where-Object {$_.IPAddress -match "^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)"} | Select-Object -First 1).IPAddress' |
+            powershell.exe -NoProfile -Command '
+                $ErrorActionPreference = "Stop"
+                try {
+                    $route = Get-NetRoute `
+                        -AddressFamily IPv4 `
+                        -DestinationPrefix "0.0.0.0/0" `
+                        -PolicyStore ActiveStore |
+                        Sort-Object @{Expression = { $_.RouteMetric + $_.InterfaceMetric }} |
+                        Select-Object -First 1
+
+                    if ($null -eq $route) { exit 1 }
+
+                    $ip = Get-NetIPAddress `
+                        -AddressFamily IPv4 `
+                        -InterfaceIndex $route.InterfaceIndex `
+                        -AddressState Preferred |
+                        Where-Object {
+                            $_.IPAddress -match "^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)"
+                        } |
+                        Select-Object -First 1 -ExpandProperty IPAddress
+
+                    if ($ip) {
+                        $ip
+                        exit 0
+                    }
+
+                    exit 1
+                } catch {
+                    exit 1
+                }
+            ' |
                 tr -d '\r'
             ;;
         *)
@@ -67,6 +90,8 @@ is_valid_ipv4() {
 }
 
 is_private_ipv4() {
+    is_valid_ipv4 "$1" || return 1
+
     case "$1" in
         10.*|192.168.*|172.16.*|172.17.*|172.18.*|172.19.*|172.2[0-9].*|172.3[0-1].*)
             return 0

--- a/tests/run_with_router.sh
+++ b/tests/run_with_router.sh
@@ -124,12 +124,31 @@ cd "$TESTDIR"|| exit
 echo "------------------ Running test $TESTBIN -------------------"
 
 cleanup() {
-    if [ -n "${ZPID:-}" ]; then
-        kill -9 "$ZPID" 2>/dev/null || true
-    fi
+    stop_router
 }
 
 trap cleanup EXIT INT TERM
+
+stop_router() {
+    if [ -z "${ZPID:-}" ]; then
+        return
+    fi
+
+    kill -TERM "$ZPID" 2>/dev/null || true
+
+    attempts=0
+    while kill -0 "$ZPID" 2>/dev/null && [ "$attempts" -lt 20 ]; do
+        sleep 0.1
+        attempts=$((attempts + 1))
+    done
+
+    if kill -0 "$ZPID" 2>/dev/null; then
+        kill -KILL "$ZPID" 2>/dev/null || true
+    fi
+
+    wait "$ZPID" 2>/dev/null || true
+    ZPID=
+}
 
 sleep 5
 
@@ -163,7 +182,7 @@ for LOCATOR in $(echo "$LOCATORS" | xargs); do
     cat client."$TEST_NAME_WE".log
 
     echo "> Stopping zenohd ..."
-    kill -9 "$ZPID"
+    stop_router
 
     sleep 1
 

--- a/tests/run_with_router.sh
+++ b/tests/run_with_router.sh
@@ -25,6 +25,14 @@ cd "$TESTDIR"|| exit
 
 echo "------------------ Running test $TESTBIN -------------------"
 
+cleanup() {
+    if [ -n "${ZPID:-}" ]; then
+        kill -9 "$ZPID" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT INT TERM
+
 sleep 5
 
 if [ ! -f zenohd ]; then
@@ -39,7 +47,7 @@ fi
 
 chmod +x zenohd
 
-LOCATORS="tcp/0.0.0.0:7447"
+LOCATORS="${ZENOH_TEST_ROUTER_LISTENER:-tcp/127.0.0.1:7447}"
 for LOCATOR in $(echo "$LOCATORS" | xargs); do
     sleep 1
 

--- a/tests/run_with_router.sh
+++ b/tests/run_with_router.sh
@@ -39,7 +39,7 @@ fi
 
 chmod +x zenohd
 
-LOCATORS="tcp/127.0.0.1:7447"
+LOCATORS="tcp/0.0.0.0:7447"
 for LOCATOR in $(echo "$LOCATORS" | xargs); do
     sleep 1
 


### PR DESCRIPTION
This avoids issue with zenoh-pico not receiving locators from loopback only interfaces during scouting (see
https://github.com/eclipse-zenoh/zenoh-pico/issues/1283)